### PR TITLE
BI-1909

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIPrimaryEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIPrimaryEntity.java
@@ -6,12 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
 import io.swagger.model.ExternalReferences;
 import io.swagger.model.ExternalReferencesInner;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/CoordinateEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/CoordinateEntity.java
@@ -1,10 +1,7 @@
 package org.brapi.test.BrAPITestServer.model.entity;
 
 import java.math.BigDecimal;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Table(name="coordinate")
@@ -15,7 +12,7 @@ public class CoordinateEntity extends BrAPIBaseEntity{
 	private BigDecimal latitude;
 	@Column(precision = 9, scale = 6)
 	private BigDecimal altitude;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GeoJSONEntity geoJSON;
 	
 	public GeoJSONEntity getGeoJSON() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DataLinkEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DataLinkEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -26,7 +23,7 @@ public class DataLinkEntity extends BrAPIBaseEntity {
 	private String url;
 	@Column
 	private String version;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public String getDataFormat() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DatasetAuthorshipEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DatasetAuthorshipEntity.java
@@ -2,10 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -20,7 +17,7 @@ public class DatasetAuthorshipEntity extends BrAPIBaseEntity {
 	private Date publicReleaseDate;
 	@Column
 	private Date submissionDate;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
 	
 	public TrialEntity getTrial() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/EnvironmentParametersEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/EnvironmentParametersEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -24,7 +21,7 @@ public class EnvironmentParametersEntity extends BrAPIBaseEntity {
 	private String value;
 	@Column
 	private String valuePUI;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public StudyEntity getStudy() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ExperimentalDesignEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ExperimentalDesignEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -14,7 +11,7 @@ public class ExperimentalDesignEntity extends BrAPIBaseEntity {
 	private String PUI;
 	@Column
 	private String description;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public StudyEntity getStudy() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/GrowthFacilityEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/GrowthFacilityEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -14,7 +11,7 @@ public class GrowthFacilityEntity extends BrAPIBaseEntity {
 	private String PUI;
 	@Column
 	private String description;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public StudyEntity getStudy() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListEntity.java
@@ -3,12 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -32,7 +27,7 @@ public class ListEntity extends BrAPIPrimaryEntity {
 	@Column
 	private ListTypes listType;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private PersonEntity listOwnerPerson;
 	@OneToMany(mappedBy="list", cascade = CascadeType.ALL)
 	private List<ListItemEntity> data;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
@@ -1,17 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name = "list_item")
 public class ListItemEntity extends BrAPIBaseEntity {
-	@ManyToOne(cascade = CascadeType.ALL)
+	@ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private ListEntity list;
 	@Column
 	private String item;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/LocationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/LocationEntity.java
@@ -1,11 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
@@ -19,7 +14,7 @@ public class LocationEntity extends BrAPIPrimaryEntity{
 	private String coordinateDescription;
 	@Column
 	private String coordinateUncertainty;
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private GeoJSONEntity coordinates;
 	@Column
 	private String countryCode;
@@ -45,11 +40,11 @@ public class LocationEntity extends BrAPIPrimaryEntity{
 	private String slope;
 	@Column
 	private String topography;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private LocationEntity parentLocation;
 
 	public LocationEntity getParentLocation() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ObservationLevelEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ObservationLevelEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -14,7 +11,7 @@ public class ObservationLevelEntity extends BrAPIBaseEntity {
 	private String levelName;
 	@Column
 	private Integer levelOrder;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 	
 	public String getLevelName() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ProgramEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ProgramEntity.java
@@ -2,13 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationEntity;
@@ -31,10 +25,10 @@ public class ProgramEntity extends BrAPIPrimaryEntity{
 	private ProgramTypesEnum programType;
 	@Column
 	private String documentationURL;
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private PersonEntity leadPerson;
 	
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
 	
 	@OneToMany(mappedBy="program")

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/PublicationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/PublicationEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.core;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -14,7 +11,7 @@ public class PublicationEntity extends BrAPIBaseEntity {
 	private String publicationPUI;
 	@Column 
 	private String publicationReference;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
 	
 	public String getPublicationPUI() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyEntity.java
@@ -3,16 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationEntity;
@@ -40,15 +31,15 @@ public class StudyEntity extends BrAPIPrimaryEntity {
 	private Date endDate;
 	@OneToMany(mappedBy = "study")
 	private List<EnvironmentParametersEntity> environmentParameters;
-	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private ExperimentalDesignEntity experimentalDesign;
-	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private GrowthFacilityEntity growthFacility;
-	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private StudyLastUpdateEntity lastUpdate;
 	@Column
 	private String license;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private LocationEntity location;
 	@OneToMany(mappedBy = "study")
 	private List<ObservationLevelEntity> observationLevels;
@@ -77,11 +68,11 @@ public class StudyEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String studyType;
 	
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
 
 	@OneToMany(mappedBy="study")

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyLastUpdateEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyLastUpdateEntity.java
@@ -2,10 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -16,7 +13,7 @@ public class StudyLastUpdateEntity extends BrAPIBaseEntity {
 	private Date timestamp;
 	@Column
 	private String version;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public StudyEntity getStudy() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/TrialEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/TrialEntity.java
@@ -3,15 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationEntity;
@@ -44,9 +36,9 @@ public class TrialEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String trialPUI;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
 	
 	@OneToMany(mappedBy = "trial")

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallEntity.java
@@ -1,16 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
 @Table(name="allele_call")
 public class CallEntity extends BrAPIPrimaryEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CallSetEntity callSet;
 	@Column
 	private String genotype;
@@ -20,7 +17,7 @@ public class CallEntity extends BrAPIPrimaryEntity {
 	private Double genotypeLikelihood;
 	@Column 
 	private String phaseSet;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VariantEntity variant;
 
 	public CallEntity() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallSetEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallSetEntity.java
@@ -4,14 +4,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -22,7 +15,7 @@ public class CallSetEntity extends BrAPIPrimaryEntity {
 	private String callSetName;
 	@Column
 	private Date created;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SampleEntity sample;
 	@Column
 	private Date updated;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/GenomeMapEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/GenomeMapEntity.java
@@ -3,13 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.CropEntity;
@@ -20,7 +14,7 @@ import org.brapi.test.BrAPITestServer.model.entity.core.StudyEntity;
 public class GenomeMapEntity extends BrAPIPrimaryEntity{
 	@Column
 	private String comments;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
 	@Column
 	private String documentationURL;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/LinkageGroupEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/LinkageGroupEntity.java
@@ -2,18 +2,14 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
 @Table(name="linkageGroup")
 public class LinkageGroupEntity extends BrAPIPrimaryEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GenomeMapEntity genomeMap;
 	@Column
 	private String linkageGroupName; 

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/MarkerPositionEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/MarkerPositionEntity.java
@@ -1,18 +1,15 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
 @Table(name="marker_position")
 public class MarkerPositionEntity extends BrAPIPrimaryEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private LinkageGroupEntity linkageGroup;
-	@ManyToOne	
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VariantEntity variant;
 	@Column
 	private Integer position;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/PlateEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/PlateEntity.java
@@ -3,12 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
@@ -41,13 +36,13 @@ public class PlateEntity extends BrAPIPrimaryEntity{
     private Date statusTimeStamp;
 	@OneToMany(mappedBy="plate", cascade = CascadeType.ALL)
     private List<SampleEntity> samples;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VendorPlateSubmissionEntity submission;	
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;		
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;		
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;	
 	
 	public String getPlateBarcode() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceBasesPageEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceBasesPageEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
@@ -11,7 +8,7 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 @Entity
 @Table(name="reference_bases")
 public class ReferenceBasesPageEntity extends BrAPIPrimaryEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ReferenceEntity reference;
 	@Column(length = 2048)
 	private String bases;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceEntity.java
@@ -1,10 +1,8 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
 import java.math.BigDecimal;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 
@@ -17,7 +15,7 @@ public class ReferenceEntity extends BrAPIPrimaryEntity {
 	private String md5checksum;
 	@Column
 	private String referenceName;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ReferenceSetEntity referenceSet;
 	@Column
 	private BigDecimal sourceDivergence;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceSetEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/ReferenceSetEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
@@ -21,7 +18,7 @@ public class ReferenceSetEntity extends BrAPIPrimaryEntity  {
 	private String md5checksum;
 	@Column
 	private String referenceSetName;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity sourceGermplasm;
 	@Column
 	private String sourceURI;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/SampleEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/SampleEntity.java
@@ -2,11 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.ProgramEntity;
@@ -22,15 +18,15 @@ public class SampleEntity extends BrAPIPrimaryEntity{
 	private Integer plateColumn; 
 	@Column
 	private String concentration;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private PlateEntity plate;
 	@Column
 	private String plateRow; 
@@ -50,7 +46,7 @@ public class SampleEntity extends BrAPIPrimaryEntity{
 	private String sampleType;
 	@Column
 	private String takenBy;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private TaxonEntity taxonId;
 	@Column
 	private String tissueType;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantEntity.java
@@ -4,11 +4,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
@@ -32,7 +29,7 @@ public class VariantEntity extends BrAPIPrimaryEntity {
 	private Boolean filtersPassed;
 	@Column
 	private String referenceBases;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ReferenceSetEntity referenceSet;
 	@Column(name = "variantStart")
 	private Integer start;
@@ -42,7 +39,7 @@ public class VariantEntity extends BrAPIPrimaryEntity {
 	private Date updated;
 	@Column
 	private String variantName;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VariantSetEntity variantSet;
 	@Column
 	private String variantType;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetAnalysisEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetAnalysisEntity.java
@@ -3,17 +3,14 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name = "variantset_analysis")
 public class VariantSetAnalysisEntity extends BrAPIBaseEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VariantSetEntity variantSet;
 	@Column
 	private String analysisName;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetAvailableFormatEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetAvailableFormatEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.geno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -15,7 +12,7 @@ import io.swagger.model.geno.GenoFileDataFormatEnum;
 @Entity
 @Table(name = "variantset_format")
 public class VariantSetAvailableFormatEntity extends BrAPIBaseEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VariantSetEntity variantSet;
 	@Column
 	private GenoFileDataFormatEnum dataFormat;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/VariantSetEntity.java
@@ -2,15 +2,8 @@ package org.brapi.test.BrAPITestServer.model.entity.geno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.StudyEntity;
 
@@ -23,9 +16,9 @@ public class VariantSetEntity extends BrAPIPrimaryEntity {
 	private List<VariantSetAvailableFormatEntity> availableFormats;
 	@ManyToMany(mappedBy = "variantSets")
 	private List<CallSetEntity> callSets;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ReferenceSetEntity referenceSet;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 	@OneToMany(mappedBy = "variantSet")
 	private List<VariantEntity> variants;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorFileEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorFileEntity.java
@@ -2,14 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno.vendor;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.geno.SampleEntity;
@@ -25,7 +18,7 @@ public class VendorFileEntity extends BrAPIBaseEntity {
 	private String md5sum;
 	@Column
 	private String fileType;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private VendorOrderEntity order;
 	@ManyToMany(cascade= CascadeType.ALL)
 	@JoinTable(name = "vendor_file_sample", joinColumns = {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorOrderEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorOrderEntity.java
@@ -4,13 +4,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
@@ -31,7 +25,7 @@ public class VendorOrderEntity extends BrAPIPrimaryEntity{
     private StatusEnum status;
 	@Column
     private Date statusTimeStamp;
-	@OneToOne(cascade = CascadeType.ALL, mappedBy= "order")
+	@OneToOne(cascade = CascadeType.ALL, mappedBy= "order", fetch = FetchType.LAZY)
     private VendorPlateSubmissionEntity plateSubmission;
 	@OneToMany(mappedBy="order", cascade = CascadeType.ALL)
 	private List<VendorFileEntity> files;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorPlateSubmissionEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorPlateSubmissionEntity.java
@@ -2,12 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno.vendor;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
@@ -27,7 +22,7 @@ public class VendorPlateSubmissionEntity extends BrAPIPrimaryEntity{
 	private SampleTypeEnum sampleType;
 	@OneToMany(mappedBy="submission", cascade = CascadeType.ALL)
     private List<PlateEntity> plates;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private VendorOrderEntity order;
 	
 	

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorSpecPlatformEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/vendor/VendorSpecPlatformEntity.java
@@ -2,11 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.geno.vendor;
 
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -31,7 +27,7 @@ public class VendorSpecPlatformEntity extends BrAPIBaseEntity{
     private String shippingAddress;
 	@OneToMany(mappedBy="vendorSpecPlatformDbId")
     private List<VendorSpecDeliverableEntity> deliverables;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
     private VendorSpecStandardRequirementEntity standardRequirements;
 	@Column
     private String specificRequirements;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossEntity.java
@@ -4,14 +4,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -23,13 +16,13 @@ import io.swagger.model.germ.PlannedCrossNewRequest.PlannedCrossStatusEnum;
 public class CrossEntity extends BrAPIPrimaryEntity {
 	@Column
     private CrossType crossType;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private CrossingProjectEntity crossingProject;
     @Column
     private String name;
     @Column
     private PlannedCrossStatusEnum status;
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private CrossEntity plannedCross;
     @OneToMany(mappedBy = "cross", cascade = CascadeType.ALL)
     private List<CrossParentEntity> parents;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossParentEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossParentEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationUnitEntity;
@@ -13,15 +10,15 @@ import io.swagger.model.germ.ParentType;
 @Entity
 @Table(name="cross_parent")
 public class CrossParentEntity extends BrAPIBaseEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
 	@Column
 	private ParentType parentType;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossEntity cross;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossingProjectEntity crossingProject;
 	
 	public CrossingProjectEntity getCrossingProject() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossPollinationEventEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossPollinationEventEntity.java
@@ -2,10 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.germ;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -18,7 +15,7 @@ public class CrossPollinationEventEntity extends BrAPIBaseEntity {
 	private Boolean pollinationSuccessful = null;
 	@Column
 	private Date pollinationTimeStamp = null;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossEntity cross;
 
 	public CrossEntity getCross() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossingProjectEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/CrossingProjectEntity.java
@@ -2,11 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.germ;
 
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.ProgramEntity;
@@ -18,7 +14,7 @@ public class CrossingProjectEntity extends BrAPIPrimaryEntity {
 	private String name;
 	@Column
 	private String description;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
 	@OneToMany(mappedBy = "crossingProject")
 	private List<CrossParentEntity> potentialParents;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/DonorEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/DonorEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
@@ -11,7 +8,7 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 @Entity
 @Table(name="germplasm_donor")
 public class DonorEntity extends BrAPIPrimaryEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	@Column
 	private String donorAccessionNumber;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmAttributeValueEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmAttributeValueEntity.java
@@ -2,19 +2,16 @@ package org.brapi.test.BrAPITestServer.model.entity.germ;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
 @Entity
 @Table(name="germplasm_attribute_value")
 public class GermplasmAttributeValueEntity extends BrAPIPrimaryEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmAttributeDefinitionEntity attribute;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	@Column
 	private String value;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmEntity.java
@@ -4,16 +4,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.SearchRequestEntity;
@@ -40,13 +31,13 @@ public class GermplasmEntity extends BrAPIPrimaryEntity {
 	private List<GermplasmAttributeValueEntity> attributes;
 	@Column
 	private BiologicalStatusOfAccessionCode biologicalStatusOfAccessionCode;
-	@ManyToOne(cascade = CascadeType.DETACH)
+	@ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
 	private BreedingMethodEntity breedingMethod;
 	@Column
 	private String collection;
 	@Column
 	private String countryOfOriginCode;
-	@ManyToOne(cascade = CascadeType.DETACH)
+	@ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
 	private CropEntity crop;
 	@Column
 	private String defaultDisplayName;
@@ -68,7 +59,7 @@ public class GermplasmEntity extends BrAPIPrimaryEntity {
 	private List<GermplasmInstituteEntity> institutes;
 	@Column
 	private MlsStatusEnum mlsStatus;
-	@OneToOne(cascade = CascadeType.ALL, mappedBy = "germplasm")
+	@OneToOne(cascade = CascadeType.ALL, mappedBy = "germplasm", fetch = FetchType.LAZY)
 	private PedigreeNodeEntity pedigree;
 	@ManyToMany
 	@JoinTable

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmInstituteEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmInstituteEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -19,7 +16,7 @@ public class GermplasmInstituteEntity extends BrAPIBaseEntity {
 	private String instituteName;
 	@Column
 	private String instituteAddress;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 
 	public enum InstituteTypeEnum {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmOriginEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmOriginEntity.java
@@ -1,11 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
@@ -15,9 +10,9 @@ import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
 public class GermplasmOriginEntity extends BrAPIBaseEntity{
 	@Column
 	private String coordinateUncertainty;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private GeoJSONEntity coordinates;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	
 	public GermplasmEntity getGermplasm() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmSynonymEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmSynonymEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -14,7 +11,7 @@ public class GermplasmSynonymEntity extends BrAPIBaseEntity {
 	private String synonym;
 	@Column
 	private String type;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	
 	public GermplasmEntity getGermplasm() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeEdgeEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeEdgeEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -12,9 +9,9 @@ import io.swagger.model.germ.ParentType;
 @Entity
 @Table(name="pedigree_edge")
 public class PedigreeEdgeEntity extends BrAPIPrimaryEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private PedigreeNodeEntity thisNode;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private PedigreeNodeEntity conncetedNode;
 	@Column
 	private ParentType parentType;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
@@ -5,13 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.PedigreeEdgeEntity.EdgeType;
@@ -21,13 +15,13 @@ import io.swagger.model.germ.ParentType;
 @Entity
 @Table(name = "pedigree_node")
 public class PedigreeNodeEntity extends BrAPIPrimaryEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossingProjectEntity crossingProject;
 	@Column
 	private Integer crossingYear;
 	@Column
 	private String familyCode;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	@Column
 	private String pedigreeString;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotContentMixtureEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotContentMixtureEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.germ;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -12,11 +9,11 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 public class SeedLotContentMixtureEntity extends BrAPIBaseEntity {
 	@Column
 	private Integer mixturePercentage;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossEntity cross;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SeedLotEntity seedLot;
 	
 	public Integer getMixturePercentage() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotEntity.java
@@ -4,11 +4,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.LocationEntity;
@@ -23,9 +19,9 @@ public class SeedLotEntity extends BrAPIPrimaryEntity {
 	private Date createdDate;
 	@Column
 	private Date lastUpdated;
-	@ManyToOne 
+	@ManyToOne (fetch = FetchType.LAZY)
 	private LocationEntity location;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
 	@Column
 	private String description;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotTransactionEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/SeedLotTransactionEntity.java
@@ -3,10 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.germ;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -15,9 +12,9 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 public class SeedLotTransactionEntity extends BrAPIPrimaryEntity {
 	@Column
 	private BigDecimal amount;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SeedLotEntity toSeedLot;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SeedLotEntity fromSeedLot;
 	@Column
 	private String description;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/EventEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/EventEntity.java
@@ -2,14 +2,8 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.Date;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.StudyEntity;
 
@@ -29,7 +23,7 @@ public class EventEntity extends BrAPIPrimaryEntity {
 	@ManyToMany
 	@JoinTable
 	private List<ObservationUnitEntity> observationUnits;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
 
 	public List<Date> getDates() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/EventParameterEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/EventParameterEntity.java
@@ -2,11 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -31,7 +27,7 @@ public class EventParameterEntity extends BrAPIBaseEntity {
 	private String valueDescription;
 	@ElementCollection
 	private List<String> valuesByDate;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private EventEntity event;
 
 	public String getCode() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ImageEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ImageEntity.java
@@ -3,15 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
@@ -21,7 +13,7 @@ import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
 public class ImageEntity extends BrAPIPrimaryEntity {
 	@Column
 	private byte[] imageData;
-	@ManyToOne(cascade = CascadeType.DETACH)
+	@ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
 	@Column
 	private String name;
@@ -48,7 +40,7 @@ public class ImageEntity extends BrAPIPrimaryEntity {
 	private String copyright;
 	@Column
 	private Date timeStamp;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private GeoJSONEntity coordinates;
 
 	public List<String> getDescriptiveOntologyTerms() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/MethodEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/MethodEntity.java
@@ -2,13 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -29,7 +23,7 @@ public class MethodEntity extends BrAPIPrimaryEntity implements OntologyReferenc
 	private String reference;
 	@OneToMany(mappedBy="method")
 	private List<VariableBaseEntity> variables;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private OntologyEntity ontology;
 	@JoinTable
 	@OneToMany(cascade = CascadeType.ALL)

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationEntity.java
@@ -2,12 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.Date;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
@@ -24,25 +19,25 @@ public class ObservationEntity extends BrAPIPrimaryEntity {
 	private String collector;
 	@Column
 	private Date observationTimeStamp;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationVariableEntity observationVariable;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SeasonEntity season;
 	@Column
 	private String uploadedBy;
 	@Column
 	private String value;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private GeoJSONEntity geoCoordinates;
 
 	public GeoJSONEntity getGeoCoordinates() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitEntity.java
@@ -2,13 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.CropEntity;
@@ -22,29 +16,29 @@ import org.brapi.test.BrAPITestServer.model.entity.germ.SeedLotEntity;
 @Entity
 @Table(name = "observation_unit")
 public class ObservationUnitEntity extends BrAPIPrimaryEntity {
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossEntity cross;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	@Column
 	private String observationUnitName;
 	@Column
 	private String observationUnitPUI;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private SeedLotEntity seedLot;
 	@OneToMany(mappedBy="observationUnit", cascade=CascadeType.ALL)
 	private List<TreatmentEntity> treatments;
-	@OneToOne(mappedBy="observationUnit", cascade=CascadeType.ALL)
+	@OneToOne(mappedBy="observationUnit", cascade=CascadeType.ALL, fetch = FetchType.LAZY)
 	private ObservationUnitPositionEntity position;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ProgramEntity program;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TrialEntity trial;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private StudyEntity study;
-	@OneToMany(mappedBy="observationUnit", cascade=CascadeType.ALL)
+	@OneToMany(mappedBy="observationUnit", cascade=CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<ObservationEntity> observations;
 	
 	

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitLevelRelationshipEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitLevelRelationshipEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
@@ -18,9 +15,9 @@ public class ObservationUnitLevelRelationshipEntity extends BrAPIBaseEntity {
 	private ObservationUnitHierarchyLevelEnum levelName;
 	@Column
 	private Integer levelOrder;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitPositionEntity position;
 	
 	public ObservationUnitEntity getObservationUnit() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitPositionEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitPositionEntity.java
@@ -2,12 +2,8 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.GeoJSONEntity;
 
@@ -20,7 +16,7 @@ import io.swagger.model.pheno.PositionCoordinateTypeEnum;
 public class ObservationUnitPositionEntity extends BrAPIBaseEntity {
 	@Column
 	private EntryTypeEnum entryType;
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private GeoJSONEntity geoCoordinates;
 	@Column
 	private String levelCode;
@@ -38,7 +34,7 @@ public class ObservationUnitPositionEntity extends BrAPIBaseEntity {
 	private String positionCoordinateY;
 	@Column
 	private PositionCoordinateTypeEnum positionCoordinateYType;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
 
 	public ObservationUnitEntity getObservationUnit() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationVariableEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationVariableEntity.java
@@ -2,10 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Table(name="observation_variable")
@@ -14,7 +11,7 @@ public class ObservationVariableEntity extends VariableBaseEntity{
 	private String name;
 	@Column
 	private String pui;
-	@OneToMany(mappedBy="observationVariable")
+	@OneToMany(mappedBy="observationVariable", fetch = FetchType.LAZY)
 	private List<ObservationEntity> observations;
 	
 	public String getPui() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ScaleEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ScaleEntity.java
@@ -2,13 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -35,7 +29,7 @@ public class ScaleEntity extends BrAPIPrimaryEntity implements OntologyReference
 	private List<ScaleValidValueCategoryEntity> validValueCategories;
 	@OneToMany(mappedBy = "scale", cascade = CascadeType.DETACH)
 	private List<VariableBaseEntity> variables;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private OntologyEntity ontology;
 	@JoinTable
 	@OneToMany(cascade = CascadeType.ALL)

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ScaleValidValueCategoryEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ScaleValidValueCategoryEntity.java
@@ -1,16 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name="scale_valid_value_category")
 public class ScaleValidValueCategoryEntity extends BrAPIBaseEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ScaleEntity scale;
 	@Column
 	private String label;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TaxonEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TaxonEntity.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
@@ -15,7 +12,7 @@ public class TaxonEntity extends BrAPIBaseEntity {
 	private String sourceName;
 	@Column
 	private String taxonId;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private GermplasmEntity germplasm;
 	
 	public GermplasmEntity getGermplasm() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitAbbreviationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitAbbreviationEntity.java
@@ -1,16 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name="trait_abbreviation")
 public class TraitAbbreviationEntity extends BrAPIBaseEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TraitEntity trait;
 	@Column
 	private String abbreviation;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitEntity.java
@@ -2,14 +2,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 
@@ -28,7 +21,7 @@ public class TraitEntity extends BrAPIPrimaryEntity implements OntologyReference
 	private String entityPUI;
 	@Column
 	private String mainAbbreviation;
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private OntologyEntity ontology;
 	@JoinTable
 	@OneToMany(cascade = CascadeType.ALL)

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitSynonymEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TraitSynonymEntity.java
@@ -1,16 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name="trait_synonym")
 public class TraitSynonymEntity extends BrAPIBaseEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TraitEntity trait;
 	@Column
 	private String synonym;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TreatmentEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/TreatmentEntity.java
@@ -1,16 +1,13 @@
 package org.brapi.test.BrAPITestServer.model.entity.pheno;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 
 @Entity
 @Table(name="observation_unit_treatment")
 public class TreatmentEntity extends BrAPIBaseEntity{
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ObservationUnitEntity observationUnit;
 	@Column
 	private String factor;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/VariableBaseEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/VariableBaseEntity.java
@@ -3,15 +3,7 @@ package org.brapi.test.BrAPITestServer.model.entity.pheno;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.CropEntity;
@@ -20,7 +12,7 @@ import org.brapi.test.BrAPITestServer.model.entity.core.CropEntity;
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public class VariableBaseEntity extends BrAPIPrimaryEntity implements OntologyReferenceHolder {
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private CropEntity crop;
 	@ElementCollection
 	private List<String> contextOfUse;
@@ -34,11 +26,11 @@ public class VariableBaseEntity extends BrAPIPrimaryEntity implements OntologyRe
 	private String institution;
 	@Column
 	private String language;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private MethodEntity method;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private OntologyEntity ontology;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ScaleEntity scale;
 	@Column
 	private String scientist;
@@ -48,7 +40,7 @@ public class VariableBaseEntity extends BrAPIPrimaryEntity implements OntologyRe
 	private Date submissionTimestamp;
 	@ElementCollection
 	private List<String> synonyms;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private TraitEntity trait;
 	@JoinTable
 	@OneToMany(cascade = CascadeType.ALL)

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
@@ -23,4 +23,8 @@ public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serial
 	public <S extends T> List<S> saveAll(Iterable<S> entities);
 	
 	public <S extends T> void refresh(S entity);
+
+	public void fetchXrefs(Page<T> page, Class<T> searchClass);
+
+	public void fetchAdditionalInfo(Page<T> page, Class<T> searchClass);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/SearchQueryBuilder.java
@@ -224,6 +224,11 @@ public class SearchQueryBuilder<T> {
 		return this;
 	}
 
+	public SearchQueryBuilder<T> leftJoinFetch(String join, String name) {
+		this.selectClause += "LEFT JOIN FETCH " + entityPrefix(join) + " " + paramFilter(name) + " ";
+		return this;
+	}
+
 	private String entityPrefix(String field) {
 		if (field.startsWith("*")) {
 			return field.substring(1);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ServerInfoService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ServerInfoService.java
@@ -21,7 +21,7 @@ public class ServerInfoService {
 		 return new ServiceBuilder()
 				.versions(VersionsEnum.V20, VersionsEnum.V21)
 				//CORE
-				.setBase("serviceinfo").GET().build()
+				.setBase("serverinfo").GET().build()
 				.setBase("commoncropnames").GET().build()
 				.setBase("lists").GET().POST().addPath("{listDbId}").GET().PUT().withSearch()
 				.setBase("locations").GET().POST().addPath("{locationDbId}").GET().PUT().withSearch()

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -174,9 +174,9 @@ public class ObservationService {
 
 	public List<Observation> findObservations(@Valid ObservationSearchRequest request, Metadata metadata) {
 		Page<ObservationEntity> page = findObservationEntities(request, metadata);
-		log.debug(new Date() + ": converting "+page.getSize()+" entities");
+		log.debug("converting "+page.getSize()+" entities");
 		List<Observation> observations = page.map(this::convertFromEntity).getContent();
-		log.debug(new Date() + ": done converting entities");
+		log.debug("done converting entities");
 		PagingUtility.calculateMetaData(metadata, page);
 		return observations;
 	}
@@ -254,11 +254,13 @@ public class ObservationService {
 				.appendList(request.getStudyDbIds(), "study.id").appendList(request.getStudyNames(), "study.studyName")
 				.appendList(request.getTrialDbIds(), "trial.id").appendList(request.getTrialNames(), "trial.trialName");
 
-		log.debug(new Date() + ": starting search");
+		log.debug("starting search");
 		Page<ObservationEntity> page = observationRepository.findAllBySearch(searchQuery, pageReq);
-		log.debug(new Date() + ": search complete");
+		log.debug("search complete");
 
-		observationRepository.fetchXrefs(page, ObservationEntity.class);
+		if(!page.isEmpty()) {
+			observationRepository.fetchXrefs(page, ObservationEntity.class);
+		}
 		return page;
 	}
 
@@ -329,7 +331,7 @@ public class ObservationService {
 	}
 
 	public Observation convertFromEntity(ObservationEntity entity) {
-		log.trace(new Date() + ": converting obs: " + entity.getId());
+		log.trace("converting obs: " + entity.getId());
 		Observation observation = new Observation();
 		if (entity != null) {
 			UpdateUtility.convertFromEntity(entity, observation);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -21,6 +21,8 @@ import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
 import org.brapi.test.BrAPITestServer.service.UpdateUtility;
 import org.brapi.test.BrAPITestServer.service.core.SeasonService;
 import org.brapi.test.BrAPITestServer.service.core.StudyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +42,8 @@ import io.swagger.model.pheno.ObservationUnitLevelRelationship;
 
 @Service
 public class ObservationService {
+
+	private static final Logger log = LoggerFactory.getLogger(ObservationService.class);
 
 	private final ObservationRepository observationRepository;
 	private final SeasonService seasonService;
@@ -170,9 +174,9 @@ public class ObservationService {
 
 	public List<Observation> findObservations(@Valid ObservationSearchRequest request, Metadata metadata) {
 		Page<ObservationEntity> page = findObservationEntities(request, metadata);
-		System.out.println(new Date() + ": converting "+page.getSize()+" entities");
+		log.debug(new Date() + ": converting "+page.getSize()+" entities");
 		List<Observation> observations = page.map(this::convertFromEntity).getContent();
-		System.out.println(new Date() + ": done converting entities");
+		log.debug(new Date() + ": done converting entities");
 		PagingUtility.calculateMetaData(metadata, page);
 		return observations;
 	}
@@ -250,13 +254,11 @@ public class ObservationService {
 				.appendList(request.getStudyDbIds(), "study.id").appendList(request.getStudyNames(), "study.studyName")
 				.appendList(request.getTrialDbIds(), "trial.id").appendList(request.getTrialNames(), "trial.trialName");
 
-		System.out.println(new Date() + ": starting search");
+		log.debug(new Date() + ": starting search");
 		Page<ObservationEntity> page = observationRepository.findAllBySearch(searchQuery, pageReq);
-		System.out.println(new Date() + ": search complete");
+		log.debug(new Date() + ": search complete");
 
-		System.out.println("fetching Obs xrefs: " + new Date());
 		observationRepository.fetchXrefs(page, ObservationEntity.class);
-		System.out.println("done fetching Obs xrefs: " + new Date());
 		return page;
 	}
 
@@ -327,7 +329,7 @@ public class ObservationService {
 	}
 
 	public Observation convertFromEntity(ObservationEntity entity) {
-		System.out.println(new Date() + ": converting obs: " + entity.getId());
+		log.trace(new Date() + ": converting obs: " + entity.getId());
 		Observation observation = new Observation();
 		if (entity != null) {
 			UpdateUtility.convertFromEntity(entity, observation);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -57,17 +57,11 @@ import io.swagger.model.pheno.ObservationUnitTable;
 import io.swagger.model.pheno.ObservationVariable;
 import io.swagger.model.pheno.ObservationVariableSearchRequest;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-
 @Service
 public class ObservationUnitService {
 
 	private static final Logger log = LoggerFactory.getLogger(ObservationUnitService.class);
 	private final ObservationUnitRepository observationUnitRepository;
-
-	private final EntityManager entityManager;
-
 	private final GermplasmService germplasmService;
 	private final CrossService crossService;
 	private final ObservationService observationService;
@@ -81,9 +75,8 @@ public class ObservationUnitService {
 	public ObservationUnitService(ObservationUnitRepository observationUnitRepository, StudyService studyService,
 			TrialService trialService, ProgramService programService, ObservationService observationService,
 			GermplasmService germplasmService, SeedLotService seedLotService, CrossService crossService,
-			ObservationVariableService observationVariableService, EntityManager entityManager) {
+			ObservationVariableService observationVariableService) {
 		this.observationUnitRepository = observationUnitRepository;
-		this.entityManager = entityManager;
 
 		this.studyService = studyService;
 		this.trialService = trialService;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -208,9 +208,9 @@ public class ObservationUnitService {
 			}
 		}
 
-		log.debug(new Date() + ": converting "+page.getSize()+" entities");
+		log.debug("converting "+page.getSize()+" entities");
 		List<ObservationUnit> observationUnits = page.map(observationUnitEntity -> this.convertFromEntity(observationUnitEntity, includeObservations)).getContent();
-		log.debug(new Date() + ": done converting entities");
+		log.debug("done converting entities");
 		PagingUtility.calculateMetaData(metadata, page);
 
 		return observationUnits;
@@ -287,13 +287,15 @@ public class ObservationUnitService {
 				.appendList(request.getStudyNames(), "study.studyName").appendList(request.getTrialDbIds(), "trial.id")
 				.appendList(request.getTrialNames(), "trial.trailName");
 
-		log.debug("Starting search: " + new Date());
+		log.debug("Starting search");
 		Page<ObservationUnitEntity> page = observationUnitRepository.findAllBySearch(searchQuery, pageReq);
-		log.debug("Search complete: " + new Date());
+		log.debug("Search complete");
 
-		observationUnitRepository.fetchXrefs(page, ObservationUnitEntity.class);
-		fetchTreatments(page);
-		fetchObsUnitLevelRelationships(page);
+		if(!page.isEmpty()) {
+			observationUnitRepository.fetchXrefs(page, ObservationUnitEntity.class);
+			fetchTreatments(page);
+			fetchObsUnitLevelRelationships(page);
+		}
 		return page;
 	}
 
@@ -451,7 +453,7 @@ public class ObservationUnitService {
 	}
 
 	private ObservationUnit convertFromEntity(ObservationUnitEntity entity, boolean convertObservations) {
-		log.trace(new Date() + ": converting ou: " + entity.getId());
+		log.trace("converting ou: " + entity.getId());
 		ObservationUnit unit = new ObservationUnit();
 		UpdateUtility.convertFromEntity(entity, unit);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
@@ -21,6 +21,8 @@ import org.brapi.test.BrAPITestServer.service.PagingUtility;
 import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
 import org.brapi.test.BrAPITestServer.service.UpdateUtility;
 import org.brapi.test.BrAPITestServer.service.core.CropService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +41,8 @@ import io.swagger.model.pheno.VariableBaseClass;
 
 @Service
 public class ObservationVariableService {
+
+	private static final Logger log = LoggerFactory.getLogger(ObservationVariableService.class);
 	private final ObservationVariableRepository observationVariableRepository;
 	private final MethodRepository methodRepository;
 	private final ScaleRepository scaleRepository;
@@ -137,43 +141,23 @@ public class ObservationVariableService {
 				.appendList(request.getTraitDbIds(), "trait.id")
 				.appendEnumList(request.getDataTypes(), "scale.dataType");
 
-		System.out.println("Starting search: " + new Date());
+		log.debug("Starting variable search: " + new Date());
 		Page<ObservationVariableEntity> page = observationVariableRepository.findAllBySearch(searchQuery, pageReq);
-		System.out.println("Search complete: " + new Date());
-		System.out.println("fetching var xrefs: " + new Date());
+		log.debug("Search variable complete: " + new Date());
 		observationVariableRepository.fetchXrefs(page, ObservationVariableEntity.class);
-		System.out.println("done fetching var xrefs: " + new Date());
-		System.out.println("fetching var additionalInfo: " + new Date());
 		observationVariableRepository.fetchAdditionalInfo(page, ObservationVariableEntity.class);
-		System.out.println("done fetching var additionalInfo: " + new Date());
-		System.out.println("fetching var synonyms: " + new Date());
 		fetchSynonyms(page);
-		System.out.println("done fetching var synonyms: " + new Date());
-		System.out.println("fetching method xrefs: " + new Date());
 		fetchMethodXrefs(page);
-		System.out.println("done fetching method xrefs: " + new Date());
-		System.out.println("fetching method additionalInfo: " + new Date());
 		fetchMethodAdditionalInfo(page);
-		System.out.println("done fetching method additionalInfo: " + new Date());
-		System.out.println("fetching scale xrefs: " + new Date());
 		fetchScaleXrefs(page);
-		System.out.println("done fetching scale xrefs: " + new Date());
-		System.out.println("fetching scale additionalInfo: " + new Date());
 		fetchScaleAdditionalInfo(page);
-		System.out.println("done fetching scale additionalInfo: " + new Date());
-		System.out.println("fetching scale valid value categories: " + new Date());
 		fetchScaleValidValueCategories(page);
-		System.out.println("done fetching scale valid value categories: " + new Date());
-		System.out.println("fetching trait xrefs: " + new Date());
 		fetchTraitXrefs(page);
-		System.out.println("done fetching trait xrefs: " + new Date());
-		System.out.println("fetching trait additionalInfo: " + new Date());
 		fetchTraitAdditionalInfo(page);
-		System.out.println("done fetching trait additionalInfo: " + new Date());
 
-		System.out.println(new Date() + ": converting "+page.getSize()+" entities");
+		log.debug(new Date() + ": converting "+page.getSize()+" entities");
 		List<ObservationVariable> observationVariables = page.map(this::convertFromEntity).getContent();
-		System.out.println(new Date() + ": done converting entities");
+		log.debug(new Date() + ": done converting entities");
 		PagingUtility.calculateMetaData(metadata, page);
 		return observationVariables;
 	}
@@ -334,7 +318,7 @@ public class ObservationVariableService {
 	}
 
 	private ObservationVariable convertFromEntity(ObservationVariableEntity entity) {
-		System.out.println(new Date() + ": converting variable: " + entity.getId());
+		log.trace(new Date() + ": converting variable: " + entity.getId());
 		ObservationVariable var = new ObservationVariable();
 		convertFromBaseEntity(entity, var);
 		var.setObservationVariableName(entity.getName());

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
@@ -141,9 +141,9 @@ public class ObservationVariableService {
 				.appendList(request.getTraitDbIds(), "trait.id")
 				.appendEnumList(request.getDataTypes(), "scale.dataType");
 
-		log.debug("Starting variable search: " + new Date());
+		log.debug("Starting variable search");
 		Page<ObservationVariableEntity> page = observationVariableRepository.findAllBySearch(searchQuery, pageReq);
-		log.debug("Search variable complete: " + new Date());
+		log.debug("Variable search complete");
 		if(!page.isEmpty()) {
 			observationVariableRepository.fetchXrefs(page, ObservationVariableEntity.class);
 			observationVariableRepository.fetchAdditionalInfo(page, ObservationVariableEntity.class);
@@ -157,9 +157,9 @@ public class ObservationVariableService {
 			fetchTraitAdditionalInfo(page);
 		}
 
-		log.debug(new Date() + ": converting "+page.getSize()+" entities");
+		log.debug("converting "+page.getSize()+" entities");
 		List<ObservationVariable> observationVariables = page.map(this::convertFromEntity).getContent();
-		log.debug(new Date() + ": done converting entities");
+		log.debug("done converting entities");
 		PagingUtility.calculateMetaData(metadata, page);
 		return observationVariables;
 	}
@@ -320,7 +320,7 @@ public class ObservationVariableService {
 	}
 
 	private ObservationVariable convertFromEntity(ObservationVariableEntity entity) {
-		log.trace(new Date() + ": converting variable: " + entity.getId());
+		log.trace("converting variable: " + entity.getId());
 		ObservationVariable var = new ObservationVariable();
 		convertFromBaseEntity(entity, var);
 		var.setObservationVariableName(entity.getName());

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationVariableService.java
@@ -144,16 +144,18 @@ public class ObservationVariableService {
 		log.debug("Starting variable search: " + new Date());
 		Page<ObservationVariableEntity> page = observationVariableRepository.findAllBySearch(searchQuery, pageReq);
 		log.debug("Search variable complete: " + new Date());
-		observationVariableRepository.fetchXrefs(page, ObservationVariableEntity.class);
-		observationVariableRepository.fetchAdditionalInfo(page, ObservationVariableEntity.class);
-		fetchSynonyms(page);
-		fetchMethodXrefs(page);
-		fetchMethodAdditionalInfo(page);
-		fetchScaleXrefs(page);
-		fetchScaleAdditionalInfo(page);
-		fetchScaleValidValueCategories(page);
-		fetchTraitXrefs(page);
-		fetchTraitAdditionalInfo(page);
+		if(!page.isEmpty()) {
+			observationVariableRepository.fetchXrefs(page, ObservationVariableEntity.class);
+			observationVariableRepository.fetchAdditionalInfo(page, ObservationVariableEntity.class);
+			fetchSynonyms(page);
+			fetchMethodXrefs(page);
+			fetchMethodAdditionalInfo(page);
+			fetchScaleXrefs(page);
+			fetchScaleAdditionalInfo(page);
+			fetchScaleValidValueCategories(page);
+			fetchTraitXrefs(page);
+			fetchTraitAdditionalInfo(page);
+		}
 
 		log.debug(new Date() + ": converting "+page.getSize()+" entities");
 		List<ObservationVariable> observationVariables = page.map(this::convertFromEntity).getContent();

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ See the NOTICE file distributed with this work for additional information
+  ~ regarding copyright ownership.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{yyyy-MM-dd HH:mm:ss.SSSZ}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.brapi" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,20 +1,3 @@
-<!--
-  ~ See the NOTICE file distributed with this work for additional information
-  ~ regarding copyright ownership.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1909

- Changed all `*ToOne` (`OneToOne`, `ManyToOne`) relationships to be fetched lazily (`fetch = FetchType.LAZY`)
- Updated search methods for Germplasm, ObservationUnits, Observations, and ObservationVariables to eagerly fetch related data that is referenced when converting Hibernate entities to BrAPI objects

# Dependencies


# Testing
See https://github.com/Breeding-Insight/bi-api/pull/291


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
