### PR TITLE
BI-2051 - Out Of Memory Error

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -381,7 +381,6 @@ public class ObservationService {
 			entity.setValue(observation.getValue());
 
 		if (observation.getObservationUnitDbId() != null) {
-			// TODO: is the DbId is all we need to insert?
 			ObservationUnitEntity observationUnit = observationUnitService
 					.getObservationUnitEntity(observation.getObservationUnitDbId());
 			entity.setObservationUnit(observationUnit);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationService.java
@@ -272,16 +272,16 @@ public class ObservationService {
 	}
 
 	public List<Observation> saveObservations(@Valid List<ObservationNewRequest> requests) throws BrAPIServerException {
-		List<Observation> savedObservations = new ArrayList<>();
-
+		List<ObservationEntity> toSave = new ArrayList<>();
 		for (ObservationNewRequest request : requests) {
 			ObservationEntity entity = new ObservationEntity();
-			updateEntity(entity, request);
-			ObservationEntity savedEntity = observationRepository.save(entity);
-			savedObservations.add(convertFromEntity(savedEntity));
+			updateEntity(entity, request);  // TODO: does updateEntity need to hit the database?
+			toSave.add(entity);
 		}
-
-		return savedObservations;
+		return observationRepository.saveAllAndFlush(toSave)
+				.stream()
+				.map(this::convertFromEntity)
+				.collect(Collectors.toList());
 	}
 
 	public List<Observation> updateObservations(@Valid Map<String, ObservationNewRequest> requests)
@@ -381,6 +381,7 @@ public class ObservationService {
 			entity.setValue(observation.getValue());
 
 		if (observation.getObservationUnitDbId() != null) {
+			// TODO: is the DbId is all we need to insert?
 			ObservationUnitEntity observationUnit = observationUnitService
 					.getObservationUnitEntity(observation.getObservationUnitDbId());
 			entity.setObservationUnit(observationUnit);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -332,16 +332,17 @@ public class ObservationUnitService {
 
 	public List<ObservationUnit> saveObservationUnits(@Valid List<ObservationUnitNewRequest> requests)
 			throws BrAPIServerException {
-		List<ObservationUnit> savedObservationUnits = new ArrayList<>();
-
+		List<ObservationUnitEntity> toSave = new ArrayList<>();
 		for (ObservationUnitNewRequest request : requests) {
 			ObservationUnitEntity entity = new ObservationUnitEntity();
-			updateEntity(entity, request);
-			ObservationUnitEntity savedEntity = observationUnitRepository.save(entity);
-			savedObservationUnits.add(convertFromEntity(savedEntity));
+			updateEntity(entity, request);  // TODO: does updateEntity need to hit the database?
+			toSave.add(entity);
 		}
 
-		return savedObservationUnits;
+		return observationUnitRepository.saveAllAndFlush(toSave)
+				.stream()
+				.map(this::convertFromEntity)
+				.collect(Collectors.toList());
 	}
 
 	public List<ObservationUnit> updateObservationUnits(@Valid Map<String, ObservationUnitNewRequest> requests)


### PR DESCRIPTION
## Description
[Jira Story](https://breedinginsight.atlassian.net/browse/BI-2051)

I was unable to find a memory leak, but I was able to improve performance by batching inserts for Observations and ObservationUnits.

I would like to reduce the number of database hits in `ObservationService::updateEntity` (and all the `updateEntity` methods) but when I tried setting the *DbId on the `ObservationEntity` object rather than fetching the whole entity from the database for related entities, it resulted in missing data in the response to the POST call, so I'll have to go back to the drawing board for that.


## Testing

1. Checkout this branch `git checkout bug/BI-2051`.
2. Make sure your `application.properties` is configured correctly with port and database that won't conflict with your usual (dockerized) brapi-server, my config is below. 
 
```server.port = 8010
server.servlet.context-path=/brapi/v2

spring.datasource.url=jdbc:postgresql://localhost:5432/local
spring.datasource.hikari.data-source-properties.stringtype=unspecified
spring.datasource.username=postgres
spring.datasource.password=postgres

spring.datasource.driver-class-name=org.postgresql.Driver

spring.flyway.locations=classpath:db/migration,classpath:org/brapi/test/BrAPITestServer/db/migration
spring.flyway.schemas=public
spring.flyway.baselineOnMigrate=true

spring.jpa.hibernate.ddl-auto=validate
spring.jpa.show-sql=false

spring.mvc.dispatch-options-request=true

security.oidc_discovery_url=https://example.com/auth/.well-known/openid-configuration
security.enabled=false
```
3. Create a database called `local` or whatever is in your datasource url `psql -U postgres` and `create database local;`.
4. Run the brapi java test server.
5. Run the following SQL against the `local` database.

```sql
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '4', 'Blueberry') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '5', 'Salmon') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '6', 'Grape') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '7', 'Alfalfa') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '8', 'Sweet Potato') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '9', 'Trout') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '10', 'Soybean') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '11', 'Cranberry') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '12', 'Cucumber') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '13', 'Oat') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '14', 'Citrus') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '15', 'Sugar Cane') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '16', 'Strawberry') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '17', 'Honey') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '18', 'Pecan') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '19', 'Lettuce') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '20', 'Cotton') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '21', 'Sorghum') ON CONFLICT DO NOTHING;
INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '22', 'Hemp') ON CONFLICT DO NOTHING;
```

6. With DeltaBreed running locally, create a new program targeting your local brapi-server (i.e. http://localhost:8010).
7. Test importing large experiments with many observations. Test multiple concurrent uploads. I tested 4 concurrent uploads with ~16000 Observations each, my test files are attached.  Heap memory usage topped out at 210MB.

Germplasm:
[RILS and Parents.xls](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211110/RILS.and.Parents.xls)

Ontology:
[bi_lettuce_ontology_v1.xlsx](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211113/bi_lettuce_ontology_v1.xlsx)

Experiment & Observations:
[SCY RIL exp(1).xls](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211102/SCY.RIL.exp.1.xls)
[SCY RIL exp(2).xls](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211103/SCY.RIL.exp.2.xls)
[SCY RIL exp(3).xls](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211104/SCY.RIL.exp.3.xls)
[SCY RIL exp(4).xls](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14211105/SCY.RIL.exp.4.xls)

