### PR TITLE
BI-2078 - BrAPI-Java-TestServer OutOfMemoryError when saving ~30K Germplasm

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
@@ -25,7 +25,7 @@ public class PedigreeNodeEntity extends BrAPIPrimaryEntity {
 	private GermplasmEntity germplasm;
 	@Column
 	private String pedigreeString;
-	@OneToMany(mappedBy = "thisNode", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "thisNode", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<PedigreeEdgeEntity> edges = new ArrayList<>();
 
 	@Override

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -326,12 +326,11 @@ public class GermplasmService {
 		return convertFromEntity(savedEntity);
 	}
 
-	// TODO: evaluate performance!
 	public List<Germplasm> saveGermplasm(@Valid List<GermplasmNewRequest> body) throws BrAPIServerException {
 		List<GermplasmEntity> toSave = new ArrayList<>();
 		for (GermplasmNewRequest germplasm : body) {
 			GermplasmEntity entity = new GermplasmEntity();
-			updateEntity(entity, germplasm);  // TODO: does updateEntity need to hit the database?
+			updateEntity(entity, germplasm);
 			toSave.add(entity);
 		}
 		// Save batch.
@@ -410,17 +409,13 @@ public class GermplasmService {
 		if (request.getBiologicalStatusOfAccessionCode() != null)
 			entity.setBiologicalStatusOfAccessionCode(request.getBiologicalStatusOfAccessionCode());
 		if (request.getBreedingMethodDbId() != null) {
-			// TODO: the DbId is all we need to insert.
-			BreedingMethodEntity method = new BreedingMethodEntity();
-			method.setId(request.getBreedingMethodDbId());
-//					breedingMethodService
-//					.getBreedingMethodEntity(request.getBreedingMethodDbId());
+			BreedingMethodEntity method = breedingMethodService
+					.getBreedingMethodEntity(request.getBreedingMethodDbId());
 			entity.setBreedingMethod(method);
 		}
 		if (request.getCollection() != null)
 			entity.setCollection(request.getCollection());
 		if (request.getCommonCropName() != null) {
-			// TODO: can we drop or batch?
 			CropEntity crop = cropService.findCropEntity(request.getCommonCropName());
 			if (crop == null) {
 				crop = cropService.saveCropEntity(request.getCommonCropName());

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import java.util.Optional;
 import java.util.Set;
 
+import io.swagger.model.IndexPagination;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.germ.CrossingProjectEntity;
@@ -484,15 +485,21 @@ public class PedigreeService {
 		UpdateUtility.updateEntity(node, entity);
 		updateEntity(entity, node);
 		if (node.getParents() != null) {
-			
-			List<String> edgeIdsToDelete = new ArrayList<>(); 
-			edgeIdsToDelete.addAll(entity.getParentEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
-			edgeIdsToDelete.addAll(entity.getParentNodes().stream().flatMap(parent -> parent.getProgenyEdges().stream())
-					.filter(childEdge -> childEdge.getConncetedNode().equals(entity))
-					.map(e -> e.getId()).collect(Collectors.toList()));
 
-			pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
-			pedigreeEdgeRepository.flush();
+			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
+			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
+			search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
+			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
+			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);
+
+			List<String> edgeIdsToDelete = new ArrayList<>();
+			edgeIdsToDelete.addAll(entity.getParentEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
+			edgeIdsToDelete.addAll(existingParentEdges.getContent().stream().map(e -> e.getId()).collect(Collectors.toList()));
+
+			if (!edgeIdsToDelete.isEmpty()) {
+				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
+				pedigreeEdgeRepository.flush();
+			}
 
 			for (PedigreeNodeParents parentNode : node.getParents()) {
 				PedigreeNodeEntity parentEntity = findOrCreatePedigreeNode(parentNode.getGermplasmDbId());
@@ -501,15 +508,21 @@ public class PedigreeService {
 			}
 		}
 		if (node.getProgeny() != null) {
-			
-			List<String> edgeIdsToDelete = new ArrayList<>(); 
-			edgeIdsToDelete.addAll(entity.getProgenyEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
-			edgeIdsToDelete.addAll(entity.getProgenyNodes().stream().flatMap(progeny -> progeny.getParentEdges().stream())
-					.filter(parentEdge -> parentEdge.getConncetedNode().equals(entity))
-					.map(e -> e.getId()).collect(Collectors.toList()));
 
-			pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
-			pedigreeEdgeRepository.flush();
+			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
+			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
+			search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
+			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
+			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);
+
+			List<String> edgeIdsToDelete = new ArrayList<>();
+			edgeIdsToDelete.addAll(entity.getProgenyEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
+			edgeIdsToDelete.addAll(existingProgenyEdges.getContent().stream().map(e -> e.getId()).collect(Collectors.toList()));
+
+			if (!edgeIdsToDelete.isEmpty()) {
+				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
+				pedigreeEdgeRepository.flush();
+			}
 
 			for (PedigreeNodeParents childNode : node.getProgeny()) {
 				PedigreeNodeEntity childEntity = findOrCreatePedigreeNode(childNode.getGermplasmDbId());


### PR DESCRIPTION
# Description
[Jira Story](https://breedinginsight.atlassian.net/browse/BI-2078)

Peter Selby made most of the code changes, I did the profiling. While more involved refactoring or schema changes could improve performance a lot, this change at least reduced the total memory footprint by an order of magnitude, hopefully it will make the `OutOfMemory` error less likely.

# Testing
The file that originally produced the `OutOfMemory` error is [P1 0.9+649 0.9+673_germplasm_2024-02-29 02-14-36+0000.xlsx](https://github.com/Breeding-Insight/brapi-Java-TestServer/files/14563761/P1.0.9%2B649.0.9%2B673_germplasm_2024-02-29.02-14-36%2B0000.xlsx). Initially it would take about 100 minutes to upload locally, after the changes it takes around 40 minutes.
