### PR TITLE
BI-2252 - BrAPI-Java-TestServer /search/germplasm endpoint OutOfMemoryError

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -112,11 +112,6 @@ public class GermplasmService {
 		Pageable pageReq = PagingUtility.getPageRequest(metadata);
 		SearchQueryBuilder<GermplasmEntity> searchQuery = new SearchQueryBuilder<GermplasmEntity>(
 				GermplasmEntity.class);
-		searchQuery.leftJoinFetch("synonyms", "synonyms")
-				.leftJoinFetch("breedingMethod", "breedingMethod")
-				.leftJoinFetch("crop", "crop")
-				.leftJoinFetch("pedigree", "pedigree")
-				.leftJoinFetch("*pedigree.crossingProject", "crossingProject");
 
 		if (request.getProgramDbIds() != null || request.getProgramNames() != null || request.getTrialDbIds() != null
 				|| request.getTrialNames() != null || request.getStudyDbIds() != null
@@ -150,25 +145,6 @@ public class GermplasmService {
 				.appendList(request.getFamilyCodes(), "familyCode");
 
 		Page<GermplasmEntity> page = germplasmRepository.findAllBySearch(searchQuery, pageReq);
-
-		if(!page.isEmpty()) {
-			log.debug("fetching xrefs");
-			fetchXrefs(page);
-			log.debug("fetching attributes");
-			fetchAttributes(page);
-			log.debug("fetching donors");
-			fetchDonors(page);
-			log.debug("fetching origins");
-			fetchOrigin(page);
-			log.debug("fetching institutes");
-			fetchInstitutes(page);
-			log.debug("fetching taxons");
-			fetchTaxons(page);
-			log.debug("fetching storage codes");
-			fetchStorageCodes(page);
-			log.debug("fetching pedigree edges");
-			fetchPedigreeEdges(page);
-		}
 
 		return page;
 	}


### PR DESCRIPTION
I profiled the BJTS while making a POST request to the `/search/germplasm` endpoint with the same data that initially produced the OutOfMemoryError on rel-test.

This is memory allocation for the unmodified code:
![image](https://github.com/user-attachments/assets/5d271cf5-933a-45db-8dfa-dfe4436b2bc9)

This is memory allocation for the modified code:
![image](https://github.com/user-attachments/assets/643d8b15-1919-40e2-871a-7ce6764977db)


While memory allocation was roughly cut in half, these changes also result in slower responses (though this isn't apparent from profiling CPU time). In my testing, the modified code took roughly 5 times longer to respond to the POST `/search/germplasm` request.