### PR TITLE
BI-2304 - Support Duplicate Germplasm in Lists Referencing Existing Germplasm

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListEntity.java
@@ -30,6 +30,7 @@ public class ListEntity extends BrAPIPrimaryEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private PersonEntity listOwnerPerson;
 	@OneToMany(mappedBy="list", cascade = CascadeType.ALL)
+	@OrderColumn(name = "position")
 	private List<ListItemEntity> data;
 
 	public PersonEntity getListOwnerPerson() {

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
@@ -11,6 +11,8 @@ public class ListItemEntity extends BrAPIBaseEntity {
 	private ListEntity list;
 	@Column
 	private String item;
+	@Column
+	private Integer position;
 	
 	public ListEntity getList() {
 		return list;
@@ -24,6 +26,10 @@ public class ListItemEntity extends BrAPIBaseEntity {
 	public void setItem(String item) {
 		this.item = item;
 	}
-	
-	
+	public Integer getPosition() {
+		return position;
+	}
+	public void setPosition(Integer position) {
+		this.position = position;
+	}
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -1,9 +1,6 @@
 package org.brapi.test.BrAPITestServer.service.core;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
@@ -237,12 +234,16 @@ public class ListService {
 		}
 
 		if (list.getData() != null) {
-			entity.setData(list.getData().stream().map((item) -> {
+			List<ListItemEntity> items = new ArrayList<>();
+			ListIterator<String> iter = list.getData().listIterator();
+			while (iter.hasNext()) {
 				ListItemEntity itemEntity = new ListItemEntity();
-				itemEntity.setItem(item);
+				itemEntity.setPosition(iter.nextIndex());
+				itemEntity.setItem(iter.next());
 				itemEntity.setList(entity);
-				return itemEntity;
-			}).collect(Collectors.toList()));
+				items.add(itemEntity);
+			}
+			entity.setData(items);
 		} else {
 			entity.setData(new ArrayList<>());
 		}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -237,11 +237,14 @@ public class ListService {
 			List<ListItemEntity> items = new ArrayList<>();
 			ListIterator<String> iter = list.getData().listIterator();
 			while (iter.hasNext()) {
-				ListItemEntity itemEntity = new ListItemEntity();
-				itemEntity.setPosition(iter.nextIndex());
-				itemEntity.setItem(iter.next());
-				itemEntity.setList(entity);
-				items.add(itemEntity);
+				String item = iter.next();
+				if (item != null) {
+					ListItemEntity itemEntity = new ListItemEntity();
+					itemEntity.setPosition(iter.nextIndex());
+					itemEntity.setItem(item);
+					itemEntity.setList(entity);
+					items.add(itemEntity);
+				}
 			}
 			entity.setData(items);
 		} else {

--- a/src/main/resources/db/migration/V002.001__update_list_positions.sql
+++ b/src/main/resources/db/migration/V002.001__update_list_positions.sql
@@ -1,0 +1,64 @@
+
+-- This migration updates existing list_item records based on DeltaBreed (Breeding Insight) specific fields.
+--
+-- These are the list types, since the BJTS uses Java enums, they are stored as int in the database.
+-- 0: germplasm
+-- 1: markers
+-- 2: programs
+-- 3: trials
+-- 4: studies
+-- 5: observationUnits
+-- 6: observations
+-- 7: observationVariables
+-- 8: samples
+
+
+-- Update germplasm list items, the goal is to use the order defined by the listEntryNumbers.
+UPDATE
+    list_item
+SET
+    position = subquery.position
+FROM
+    (
+        SELECT
+            row_number() OVER (PARTITION BY li.list_id ORDER BY (g.additional_info->'listEntryNumbers'->>xr.external_reference_id)::int) AS position,
+            li.id AS list_item_id
+        FROM
+            list_item li
+                JOIN list l ON li.list_id = l.id
+                JOIN list_external_references ler ON l.id = ler.list_entity_id
+                JOIN external_reference xr ON xr.id = ler.external_references_id AND xr.external_reference_source = 'breedinginsight.org/lists'
+                JOIN germplasm g ON li.item = g.germplasm_name
+        WHERE
+            l.list_type = 0  -- 0 is germplasm
+        ORDER BY
+            l.id
+    ) AS subquery
+WHERE
+    list_item.id = subquery.list_item_id
+;
+
+-- Update all non-germplasm list items. There is no existing order to preserve, assign sequential position values arbitrarily.
+UPDATE
+    list_item
+SET
+    position = subquery.position
+FROM
+    (
+        SELECT
+            row_number() OVER (PARTITION BY li.list_id) AS position,
+            li.id AS list_item_id
+        FROM
+            list_item li
+                JOIN list l ON li.list_id = l.id
+                JOIN list_external_references ler ON l.id = ler.list_entity_id
+                JOIN external_reference xr ON xr.id = ler.external_references_id AND xr.external_reference_source = 'breedinginsight.org/lists'
+                JOIN germplasm g ON li.item = g.germplasm_name
+        WHERE
+            l.list_type != 0  -- 0 is germplasm, here we are addressing non-germplasm lists.
+        ORDER BY
+            l.id
+    ) AS subquery
+WHERE
+    list_item.id = subquery.list_item_id
+;

--- a/src/main/resources/db/migration/V002.001__update_list_positions.sql
+++ b/src/main/resources/db/migration/V002.001__update_list_positions.sql
@@ -1,7 +1,7 @@
 
 -- This migration updates existing list_item records based on DeltaBreed (Breeding Insight) specific fields.
 --
--- These are the list types, since the BJTS uses Java enums, they are stored as int in the database.
+-- These are the list types, the BJTS uses Java enums and stores ints in the database.
 -- 0: germplasm
 -- 1: markers
 -- 2: programs
@@ -12,53 +12,55 @@
 -- 7: observationVariables
 -- 8: samples
 
+DO
+$$
+BEGIN
+    -- Update germplasm list items, the goal is to use the order defined by the listEntryNumbers.
+    UPDATE
+        list_item
+    SET
+        position = subquery.position
+    FROM
+        (
+            SELECT
+                row_number() OVER (PARTITION BY li.list_id ORDER BY (g.additional_info->'listEntryNumbers'->>xr.external_reference_id)::int) AS position,
+                li.id AS list_item_id
+            FROM
+                list_item li
+                    JOIN list l ON li.list_id = l.id
+                    JOIN list_external_references ler ON l.id = ler.list_entity_id
+                    JOIN external_reference xr ON xr.id = ler.external_references_id AND xr.external_reference_source = 'breedinginsight.org/lists'
+                    JOIN germplasm g ON li.item = g.germplasm_name
+            WHERE
+                l.list_type = 0  -- 0 is germplasm
+            ORDER BY
+                l.id
+        ) AS subquery
+    WHERE
+        list_item.id = subquery.list_item_id
+    ;
 
--- Update germplasm list items, the goal is to use the order defined by the listEntryNumbers.
-UPDATE
-    list_item
-SET
-    position = subquery.position
-FROM
-    (
-        SELECT
-            row_number() OVER (PARTITION BY li.list_id ORDER BY (g.additional_info->'listEntryNumbers'->>xr.external_reference_id)::int) AS position,
-            li.id AS list_item_id
-        FROM
-            list_item li
+    -- Update all non-germplasm list items. There is no existing order to preserve, assign sequential position values arbitrarily.
+    UPDATE
+        list_item
+    SET
+        position = subquery.position
+    FROM
+        (
+            SELECT
+                row_number() OVER (PARTITION BY li.list_id) AS position,
+                li.id AS list_item_id
+            FROM
+                list_item li
                 JOIN list l ON li.list_id = l.id
-                JOIN list_external_references ler ON l.id = ler.list_entity_id
-                JOIN external_reference xr ON xr.id = ler.external_references_id AND xr.external_reference_source = 'breedinginsight.org/lists'
-                JOIN germplasm g ON li.item = g.germplasm_name
-        WHERE
-            l.list_type = 0  -- 0 is germplasm
-        ORDER BY
-            l.id
-    ) AS subquery
-WHERE
-    list_item.id = subquery.list_item_id
-;
+            WHERE
+                l.list_type != 0  -- 0 is germplasm, here we are addressing non-germplasm lists.
+            ORDER BY
+                l.id
+        ) AS subquery
+    WHERE
+        list_item.id = subquery.list_item_id
+    ;
 
--- Update all non-germplasm list items. There is no existing order to preserve, assign sequential position values arbitrarily.
-UPDATE
-    list_item
-SET
-    position = subquery.position
-FROM
-    (
-        SELECT
-            row_number() OVER (PARTITION BY li.list_id) AS position,
-            li.id AS list_item_id
-        FROM
-            list_item li
-                JOIN list l ON li.list_id = l.id
-                JOIN list_external_references ler ON l.id = ler.list_entity_id
-                JOIN external_reference xr ON xr.id = ler.external_references_id AND xr.external_reference_source = 'breedinginsight.org/lists'
-                JOIN germplasm g ON li.item = g.germplasm_name
-        WHERE
-            l.list_type != 0  -- 0 is germplasm, here we are addressing non-germplasm lists.
-        ORDER BY
-            l.id
-    ) AS subquery
-WHERE
-    list_item.id = subquery.list_item_id
-;
+END;
+$$;

--- a/src/main/resources/db/migration/V002.001__update_list_positions.sql
+++ b/src/main/resources/db/migration/V002.001__update_list_positions.sql
@@ -23,7 +23,8 @@ BEGIN
     FROM
         (
             SELECT
-                row_number() OVER (PARTITION BY li.list_id ORDER BY (g.additional_info->'listEntryNumbers'->>xr.external_reference_id)::int) AS position,
+                -- Subtract 1 from row_number to get zero indexing.
+                row_number() OVER (PARTITION BY li.list_id ORDER BY (g.additional_info->'listEntryNumbers'->>xr.external_reference_id)::int) - 1 AS position,
                 li.id AS list_item_id
             FROM
                 list_item li
@@ -48,7 +49,8 @@ BEGIN
     FROM
         (
             SELECT
-                row_number() OVER (PARTITION BY li.list_id) AS position,
+                -- Subtract 1 from row_number to get zero indexing.
+                row_number() OVER (PARTITION BY li.list_id) - 1 AS position,
                 li.id AS list_item_id
             FROM
                 list_item li

--- a/src/main/resources/db/migration/V002__add_list_position.sql
+++ b/src/main/resources/db/migration/V002__add_list_position.sql
@@ -3,3 +3,7 @@
 -- Add position to list_item.
 ALTER TABLE list_item
 ADD COLUMN position INT NOT NULL DEFAULT 0;
+-- Add an index on the position column
+CREATE INDEX idx_list_item_position ON list_item(position);
+-- Add a composite index on list_id and position for better performance when querying items within a specific list
+CREATE INDEX idx_list_item_list_position ON list_item(list_id, position);

--- a/src/main/resources/db/migration/V002__add_list_position.sql
+++ b/src/main/resources/db/migration/V002__add_list_position.sql
@@ -1,0 +1,5 @@
+-- This migration adds a position field to list_item so that lists can be explicitly ordered.
+
+-- Add position to list_item.
+ALTER TABLE list_item
+ADD COLUMN position INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
# Description

[Jira Story](https://breedinginsight.atlassian.net/browse/BI-2304) 
[`@OrderColumn` documentation](https://docs.oracle.com/javaee/7/api/javax/persistence/OrderColumn.html)

This PR adds a `position` column to the `list_item` table and a corresponding field to the java model class. It uses the `@OrderColumn` annotation to tell hibernate to maintain the order of the list of `ListItemEntity` on `ListEntity` using this column.

> This does NOT change the API, the `position` field is hidden from the client, order is maintained transparently.

> The naming of the migrations is such that we could push the universally applicable migration, `V002__add_list_position.sql` upstream, keep the BI-specific `V002.001__update_list_positions.sql` in our fork, and have it slot cleanly between V002 and V003 migrations from upstream. For whatever reason, my IDE sorts "V002.001__" before "V002__" but flyway sorts and applies them in the intended order.

bi-web PR: https://github.com/Breeding-Insight/bi-web/pull/399
bi-api PR: https://github.com/Breeding-Insight/bi-api/pull/401

# Dependencies

bi-web branch: [feature/BI-2304](https://github.com/Breeding-Insight/bi-web/tree/feature/BI-2304)
bi-api branch: [feature/BI-2304](https://github.com/Breeding-Insight/bi-api/tree/feature/BI-2304)

# Testing

See testing section [on the bi-api PR](https://github.com/Breeding-Insight/bi-api/pull/401).