### PR TITLE
BI-2423 - Add @Where annotation to entites to filter out soft deleted rows

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DatasetAuthorshipEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/DatasetAuthorshipEntity.java
@@ -5,9 +5,11 @@ import java.util.Date;
 import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "trial_dataset_authorship")
+@Where(clause = "soft_deleted = false")
 public class DatasetAuthorshipEntity extends BrAPIBaseEntity {
 	@Column
 	private String datasetPUI;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/PublicationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/PublicationEntity.java
@@ -3,9 +3,11 @@ package org.brapi.test.BrAPITestServer.model.entity.core;
 import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "trial_publication")
+@Where(clause = "soft_deleted = false")
 public class PublicationEntity extends BrAPIBaseEntity {
 	@Column
 	private String publicationPUI;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/StudyEntity.java
@@ -9,9 +9,11 @@ import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationUnitEntity;
 import org.brapi.test.BrAPITestServer.model.entity.pheno.ObservationVariableEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "study")
+@Where(clause = "soft_deleted = false")
 public class StudyEntity extends BrAPIPrimaryEntity {
 
 	@Column

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallSetEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/CallSetEntity.java
@@ -7,9 +7,11 @@ import java.util.List;
 import javax.persistence.*;
 
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "callset")
+@Where(clause = "soft_deleted = false")
 public class CallSetEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String callSetName;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/PlateEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/geno/PlateEntity.java
@@ -14,9 +14,11 @@ import org.brapi.test.BrAPITestServer.model.entity.geno.vendor.VendorPlateSubmis
 
 import io.swagger.model.geno.PlateFormat;
 import io.swagger.model.geno.SampleType;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name="plate")
+@Where(clause = "soft_deleted = false")
 public class PlateEntity extends BrAPIPrimaryEntity{
 	@Column
     private String clientPlateDbId;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationEntity.java
@@ -11,9 +11,11 @@ import org.brapi.test.BrAPITestServer.model.entity.core.ProgramEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.SeasonEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.StudyEntity;
 import org.brapi.test.BrAPITestServer.model.entity.core.TrialEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "observation")
+@Where(clause = "soft_deleted = false")
 public class ObservationEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String collector;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/pheno/ObservationUnitEntity.java
@@ -12,9 +12,11 @@ import org.brapi.test.BrAPITestServer.model.entity.core.TrialEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.CrossEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.SeedLotEntity;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "observation_unit")
+@Where(clause = "soft_deleted = false")
 public class ObservationUnitEntity extends BrAPIPrimaryEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private CrossEntity cross;


### PR DESCRIPTION
## Description

Jira Story: [BI-2423](https://breedinginsight.atlassian.net/browse/BI-2423)

Soft deleted entities are excluded using a @Where annotation on entity classes, see [TrialEntity.java](https://github.com/Breeding-Insight/brapi-Java-TestServer/blob/b2a6ee3ce495200b139c14c29d3c930adf6542d7/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/TrialEntity.java#L15) for an example.

This PR adds the annotation to entities that may be soft deleted (it was already applied to some but not all).

Entities that needed the annotation:
- ListEntity (already had it)
- ListItemEntity (already had it)
- TrialEntity (already had it)
- SampleEntity (already had it)
- StudyEntity
- ObservationEntity 
- PlateEntity
- DatasetAuthorshipEntity
- CallSetEntity
- ObservationUnitEntity
- PublicationEntity

## Dependencies

bi-api: feature/BI-2376 branch is needed for testing

## Testing

1. Create two experiments in DeltaBreed with observations in DeltaBreed.
2. Copy the ID of one of the experiments from the URL segment on the experiment detail view.
3. Use that ID and the program ID to issue the following DELETE request to bi-api, a 204 No Content response is expected.
    - `http://localhost:8081/v1/programs/{{programId}}/experiments/{{experimentId}}?hard=false`
4. Make a GET request to the brapi-server (this assumes it's running/exposed on port 6080, you may need to edit the port).
    - `http://localhost:6080/brapi/v2/studies`

If studies are returned, the bug has been fixed. If you receive a 500 Internal Server Error response, the bug persists.

[BI-2423]: https://breedinginsight.atlassian.net/browse/BI-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ