### PR TITLE
BI-2432 BJTS List updating broken

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -268,15 +268,13 @@ public class ListService {
 			entity.setListOwnerPerson(person);
 		}
 
-		if (entity.getData() != null) {
-			entity.getData().stream().forEach((item) -> {
-				item.setList(null);
-			});
-		}
-		
 		if (list.getData() != null) {
 			// Clear existing items
-			entity.getData().clear();
+			if (entity.getData() == null) {
+				entity.setData(new ArrayList<>());
+			} else {
+				entity.getData().clear();
+			}
 
 			// Add new items
 			ListIterator<String> iter = list.getData().listIterator();

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -289,7 +289,11 @@ public class ListService {
 				}
 			}
 		} else {
-			entity.getData().clear();
+			if (entity.getData() == null) {
+				entity.setData(new ArrayList<>());
+			} else {
+				entity.getData().clear();
+			}
 		}
 
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -273,9 +273,12 @@ public class ListService {
 				item.setList(null);
 			});
 		}
-
+		
 		if (list.getData() != null) {
-			List<ListItemEntity> items = new ArrayList<>();
+			// Clear existing items
+			entity.getData().clear();
+
+			// Add new items
 			ListIterator<String> iter = list.getData().listIterator();
 			while (iter.hasNext()) {
 				String item = iter.next();
@@ -284,12 +287,12 @@ public class ListService {
 					itemEntity.setPosition(iter.nextIndex());
 					itemEntity.setItem(item);
 					itemEntity.setList(entity);
-					items.add(itemEntity);
+					entity.getData().add(itemEntity);
 				}
 			}
-			entity.setData(items);
 		} else {
-			entity.setData(new ArrayList<>());
+			entity.getData().clear();
 		}
+
 	}
 }


### PR DESCRIPTION
Story: [BI-2432](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2432)

## Problem
`ListService#updateList` is experiencing a runtime error whenever committing changes to the database via Hibernate.

1.  The method is detaching all existing items from the list by setting their list reference to null.
2.  It then creates a new list of items and sets it on the entity, effectively replacing the entire collection.

This approach can cause issues with Hibernate's collection management, especially with orphanRemoval = true, as it may not properly track which items should be deleted. The orphanRemoval = true setting in the OneToMany annotation was introduced as part of [BI-2374](https://breedinginsight.atlassian.net/browse/BI-2374).

## Solution
- Instead of creating a new list and setting it, we clear the existing list and add new items to it.
- We maintain the bidirectional relationship by setting the list reference on each new item.
- If list.getData() is null, we simply clear the existing items without creating a new empty list.

## Acceptance Criteria

1. Using the Deltabreed UI, import an experiment with a dataset (can be empty or can have observation data)
2. Download the experiment data and copy the obsrvation unit dbids to a new import sheet with updated observation  data
3. Run the appendOverwrite workflow and import the changes
4. View the experiment details and verify that the updates were made without error

[BI-2432]: https://breedinginsight.atlassian.net/browse/BI-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2374]: https://breedinginsight.atlassian.net/browse/BI-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ