### PR TITLE
BI-2438 Regression: Append Workflow Messes Up Experiment Display And Download

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/core/ListItemEntity.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Table(name = "list_item")
 @Where(clause = "soft_deleted = false")
 public class ListItemEntity extends BrAPIBaseEntity {
-	@ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	private ListEntity list;
 	@Column
 	private String item;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/ListService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -247,7 +248,7 @@ public class ListService {
 	}
 
 	private void updateEntity(ListEntity entity, @Valid ListNewRequest list) throws BrAPIServerException {
-
+		// Update simple fields
 		if (list.getAdditionalInfo() != null)
 			entity.setAdditionalInfo(list.getAdditionalInfo());
 		if (list.getListDescription() != null)
@@ -268,33 +269,46 @@ public class ListService {
 			entity.setListOwnerPerson(person);
 		}
 
+		// Update list items
 		if (list.getData() != null) {
-			// Clear existing items
+			// Initialize entity.getData() if it's null
 			if (entity.getData() == null) {
 				entity.setData(new ArrayList<>());
-			} else {
-				entity.getData().clear();
 			}
 
-			// Add new items
-			ListIterator<String> iter = list.getData().listIterator();
-			while (iter.hasNext()) {
-				String item = iter.next();
+			// Create a map of existing items for efficient lookup
+			Map<String, ListItemEntity> existingItems = entity.getData().stream()
+					.filter(item -> item.getItem() != null)
+					.collect(Collectors.toMap(
+							ListItemEntity::getItem,
+							Function.identity(),
+							(existing, replacement) -> existing,
+							HashMap::new
+					));
+
+			List<ListItemEntity> updatedItems = new ArrayList<>();
+			int position = 0;
+
+			for (String item : list.getData()) {
 				if (item != null) {
-					ListItemEntity itemEntity = new ListItemEntity();
-					itemEntity.setPosition(iter.nextIndex());
-					itemEntity.setItem(item);
-					itemEntity.setList(entity);
-					entity.getData().add(itemEntity);
+					ListItemEntity itemEntity = existingItems.get(item);
+					if (itemEntity == null) {
+						// Create new item if it doesn't exist
+						itemEntity = new ListItemEntity();
+						itemEntity.setItem(item);
+						itemEntity.setList(entity);
+					}
+					itemEntity.setPosition(position++);
+					updatedItems.add(itemEntity);
 				}
 			}
-		} else {
-			if (entity.getData() == null) {
-				entity.setData(new ArrayList<>());
-			} else {
-				entity.getData().clear();
-			}
-		}
 
+			// Update the list with new and updated items
+			entity.getData().clear();
+			entity.getData().addAll(updatedItems);
+		} else {
+			// If data is null, initialize an empty list
+			entity.setData(new ArrayList<>());
+		}
 	}
 }


### PR DESCRIPTION
[BI-2438](https://breedinginsight.atlassian.net/browse/BI-2438)

### Problem Description
There's an issue when using the "Append experimental dataset" workflow. To reproduce:
1. Upload germplasm.  
2. Upload ontology. 
3. Upload experiment. 
4. Download experiment (with ObsUnitIds) and fill in the observation values for the "X Free Txt" column.
5. Upload that file (with observation values) using the "Append experimental dataset" workflow. Note that the preview will look good.
6. Go to the experiment detail/dataset view. Note that the observation columns are now completely absent from the table.
7. Try to download the experiment. This will also result in an error.

### Resolution
When ListService updates the data of a list, the removal of a child ListItemEntity is triggering a deletion of the parent ListEntity. 

`ListService#updateEntity` was refactored:

- instead of clearing and re-adding all items, we create a map of existing items;
- we iterate through the new data, reusing existing items where possible and creating new ones only when necessary;
- we remove items that are no longer in the list; and
- we clear and add all updated items to maintain the correct order.

This approach should prevent the cascading delete while still updating the list items. It also maintains the existing ListItemEntity objects where possible, which is more efficient and prevents unnecessary database operations.

`ListItemEntity` no longer cascades all operations in ManyToOne relationship with ListEntity. Cascading all operations is what was most likely causing the removal of a listItem to trigger a list deletion.

### Acceptance Criteria
- perform the steps outlined in the problem description and verify there is no error.

[BI-2438]: https://breedinginsight.atlassian.net/browse/BI-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ