### PR TITLE
BI-2431 & BI-2475 - BrAPI Server changes to support Sample & Plate deletion

### DIFF
--- a/src/main/java/io/swagger/model/core/BatchDeleteSearchRequest.java
+++ b/src/main/java/io/swagger/model/core/BatchDeleteSearchRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.model.SearchRequest;
+import io.swagger.model.geno.PlateSearchRequest;
 import io.swagger.model.geno.SampleSearchRequest;
 import io.swagger.model.germ.GermplasmSearchRequest;
 
@@ -17,7 +18,8 @@ public class BatchDeleteSearchRequest extends SearchRequest {
 			@JsonSubTypes.Type(value = GermplasmSearchRequest.class, name = "germplasm"),
 			@JsonSubTypes.Type(value = ListSearchRequest.class, name = "lists"),
 			@JsonSubTypes.Type(value = TrialSearchRequest.class, name = "trials"),
-			@JsonSubTypes.Type(value = SampleSearchRequest.class, name = "samples")
+			@JsonSubTypes.Type(value = SampleSearchRequest.class, name = "samples"),
+			@JsonSubTypes.Type(value = PlateSearchRequest.class, name = "plates")
 	})
 	private SearchRequest searchRequest = null;
 

--- a/src/main/java/io/swagger/model/core/BatchDeleteTypes.java
+++ b/src/main/java/io/swagger/model/core/BatchDeleteTypes.java
@@ -11,7 +11,8 @@ public enum BatchDeleteTypes {
   GERMPLASM("germplasm"),
   LISTS("lists"),
   TRIALS("trials"),
-  SAMPLES("samples");
+  SAMPLES("samples"),
+  PLATES("plates");
 
 
   private final String value;

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/core/BatchDeletesApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/core/BatchDeletesApiController.java
@@ -113,10 +113,11 @@ public class BatchDeletesApiController extends BrAPIController implements BatchD
 		BrAPIComponent component = componentFactory.getComponent(batchType);
 
 		// Return the searchDbId with a 202 if the search is too in-depth with several parameters
-		String searchReqDbId = searchService.saveSearchRequest(body, SearchRequestEntity.SearchRequestTypes.BATCHES);
-		if (searchReqDbId != null) {
-			return responseAccepted(searchReqDbId);
-		}
+		// TODO: disabled for now
+		//String searchReqDbId = searchService.saveSearchRequest(body, SearchRequestEntity.SearchRequestTypes.BATCHES);
+		//if (searchReqDbId != null) {
+		//	return responseAccepted(searchReqDbId);
+		//}
 
 		// Fetch requested BrAPI entities
 		SearchRequest entitySearch = body.getSearchRequest();

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/geno/PlateComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/geno/PlateComponent.java
@@ -1,0 +1,51 @@
+package org.brapi.test.BrAPITestServer.factory.geno;
+
+import io.swagger.model.Metadata;
+import io.swagger.model.core.BatchDeleteTypes;
+import io.swagger.model.geno.Plate;
+import io.swagger.model.geno.PlateSearchRequest;
+import org.apache.commons.lang3.NotImplementedException;
+import org.brapi.test.BrAPITestServer.factory.BrAPIComponent;
+import org.brapi.test.BrAPITestServer.service.geno.PlateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PlateComponent implements BrAPIComponent<Plate, PlateSearchRequest> {
+    private final PlateService plateService;
+
+    @Autowired
+    public PlateComponent(PlateService plateService) {
+        this.plateService = plateService;
+    }
+
+    @Override
+    public List<Plate> findEntities(PlateSearchRequest request, Metadata metadata) {
+        return plateService.findPlates(request, metadata);
+    }
+
+    @Override
+    public BatchDeleteTypes getBatchDeleteType() {
+        return BatchDeleteTypes.PLATES;
+    }
+
+
+    @Override
+    public List<String> collectDbIds(List<Plate> entities) {
+        return entities.stream().map(Plate::getPlateDbId).collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteBatchDeleteData(List<String> dbIds) {
+        plateService.deletePlateBatch(dbIds);
+    }
+
+    @Override
+    public void softDeleteBatchDeleteData(List<String> dbIds) {
+        //TODO: implement if needed in future
+        throw new NotImplementedException("plate softDeleteBatchDeleteData not implemented");
+    }
+}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/geno/PlateService.java
@@ -154,6 +154,10 @@ public class PlateService {
 
 	}
 
+	public void deletePlateBatch(List<String> plateDbIds) {
+		plateRepository.deleteAllByIdInBatch(plateDbIds);
+	}
+
 	private void updateEntity(PlateEntity entity, PlateNewRequest plate) throws BrAPIServerException {
 		UpdateUtility.updateEntity(plate, entity);
 		if (plate.getPlateName() != null) {


### PR DESCRIPTION
Combined two stories into one PR to make testing easier: [BI-2431](https://breedinginsight.atlassian.net/browse/BI-2431?atlOrigin=eyJpIjoiYjZiZmM2NWIzZDI3NDc1OWJhNzNkMjI0MDE0MTI4NzUiLCJwIjoiaiJ9) & [BI-2475](https://breedinginsight.atlassian.net/browse/BI-2475?atlOrigin=eyJpIjoiYjlkM2FkNTIxN2JkNDE5MWJlMmQzNTcwNmQxNmU2YmQiLCJwIjoiaiJ9)

- Disabled delayed search for batch delete and always do immediate response
  - There were issues with the delayed response functionality and it added unnecessary complexity, if we hit timeouts we can re-evaluate
- Added hard delete support for plates for batchDeletes, soft delete support can be added later if needed; didn't want to increase scope

Testing:
Test with bi-web BI-2380 and bi-api BI-2379. Follow acceptance criteria described in BI-2380

[BI-2431]: https://breedinginsight.atlassian.net/browse/BI-2431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2475]: https://breedinginsight.atlassian.net/browse/BI-2475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ