### PR TITLE
BI-2476 Create Single and Batch Delete End Points for Germplasm

### DIFF
--- a/src/main/java/io/swagger/api/germ/GermplasmApi.java
+++ b/src/main/java/io/swagger/api/germ/GermplasmApi.java
@@ -7,6 +7,8 @@ package io.swagger.api.germ;
 
 import io.swagger.model.BrAPIResponse;
 import io.swagger.model.Model202AcceptedSearchResponse;
+import io.swagger.model.core.ListsListResponse;
+import io.swagger.model.core.ListsSingleResponse;
 import io.swagger.model.germ.GermplasmListResponse;
 import io.swagger.model.germ.GermplasmMCPDResponse;
 import io.swagger.model.germ.GermplasmNewRequest;
@@ -42,6 +44,20 @@ public interface GermplasmApi {
 	@RequestMapping(value = "/germplasm/{germplasmDbId}", produces = { "application/json" }, method = RequestMethod.GET)
 	ResponseEntity<GermplasmSingleResponse> germplasmGermplasmDbIdGet(
 			@ApiParam(value = "The internal id of the germplasm", required = true) @PathVariable("germplasmDbId") String germplasmDbId,
+			@ApiParam(value = "HTTP HEADER - Token used for Authorization   <strong> Bearer {token_string} </strong>") @RequestHeader(value = "Authorization", required = false) String authorization)
+			throws BrAPIServerException;
+
+	@ApiOperation(value = "Delete an existing germplasm", nickname = "germplasmGermplasmDbIdDelete", notes = "Delete an existing germplasm", response = GermplasmSingleResponse.class, authorizations = {
+			@Authorization(value = "AuthorizationToken") }, tags = { "Germplasm", })
+	@ApiResponses(value = { @ApiResponse(code = 204, message = "OK", response = GermplasmSingleResponse.class),
+			@ApiResponse(code = 400, message = "Bad Request", response = String.class),
+			@ApiResponse(code = 401, message = "Unauthorized", response = String.class),
+			@ApiResponse(code = 403, message = "Forbidden", response = String.class),
+			@ApiResponse(code = 404, message = "Not Found", response = String.class) })
+	@RequestMapping(value = "/germplasm/{germplasmDbId}", produces = { "application/json" }, method = RequestMethod.DELETE)
+	ResponseEntity<GermplasmSingleResponse> germplasmGermplasmDbIdDelete(
+			@ApiParam(value = "The unique ID of this germplasm", required = true) @PathVariable("germplasmDbId") String germplasmDbId,
+			@ApiParam(value = "hardDelete") @Valid @RequestParam(value = "hardDelete", defaultValue = "false", required = false) boolean hardDelete,
 			@ApiParam(value = "HTTP HEADER - Token used for Authorization   <strong> Bearer {token_string} </strong>") @RequestHeader(value = "Authorization", required = false) String authorization)
 			throws BrAPIServerException;
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
@@ -2,6 +2,7 @@ package org.brapi.test.BrAPITestServer.controller.germ;
 
 import io.swagger.model.BrAPIResponse;
 import io.swagger.model.Metadata;
+import io.swagger.model.core.ListsSingleResponse;
 import io.swagger.model.germ.Germplasm;
 import io.swagger.model.germ.GermplasmListResponse;
 import io.swagger.model.germ.GermplasmListResponseResult;
@@ -16,6 +17,7 @@ import io.swagger.model.germ.GermplasmSearchRequest;
 import io.swagger.model.germ.GermplasmProgenyResponse;
 import io.swagger.api.germ.GermplasmApi;
 
+import jakarta.validation.Valid;
 import org.brapi.test.BrAPITestServer.controller.core.BrAPIController;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.SearchRequestEntity;
@@ -70,6 +72,26 @@ public class GermplasmApiController extends BrAPIController implements Germplasm
 		validateAcceptHeader(request);
 		Germplasm data = germplasmService.getGermplasm(germplasmDbId);
 		return responseOK(new GermplasmSingleResponse(), data);
+	}
+
+	@CrossOrigin
+	@Override
+	public ResponseEntity<GermplasmSingleResponse> germplasmGermplasmDbIdDelete(
+		@PathVariable("germplasmDbId") String germplasmDbId,
+		@Valid @RequestParam(value = "hardDelete", defaultValue = "false" ,required = false) boolean hardDelete,
+		@RequestHeader(value = "Authorization", required = false) String authorization) throws BrAPIServerException {
+
+			log.debug("Request: " + request.getRequestURI());
+			validateSecurityContext(request, "ROLE_USER");
+			validateAcceptHeader(request);
+
+			if (hardDelete) {
+				germplasmService.deleteGermplasm(germplasmDbId);
+				return responseNoContent();
+			}
+
+			germplasmService.softDeleteGermplasm(germplasmDbId);
+			return responseNoContent();
 	}
 
 	@CrossOrigin

--- a/src/main/java/org/brapi/test/BrAPITestServer/factory/germ/GermplasmComponent.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/factory/germ/GermplasmComponent.java
@@ -40,11 +40,11 @@ public class GermplasmComponent implements BrAPIComponent<Germplasm, GermplasmSe
 
     @Override
     public void deleteBatchDeleteData(List<String> dbIds) {
-
+        germplasmService.deleteGermplasmBatch(dbIds);
     }
 
     @Override
     public void softDeleteBatchDeleteData(List<String> dbIds) {
-
+        germplasmService.softDeleteGermplasmBatch(dbIds);
     }
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/GermplasmEntity.java
@@ -17,9 +17,11 @@ import io.swagger.model.germ.BiologicalStatusOfAccessionCode;
 import io.swagger.model.germ.GermplasmMCPD.AcquisitionSourceCodeEnum;
 import io.swagger.model.germ.GermplasmMCPD.MlsStatusEnum;
 import io.swagger.model.germ.GermplasmStorageTypesEnum;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "germplasm")
+@Where(clause = "soft_deleted = false")
 public class GermplasmEntity extends BrAPIPrimaryEntity {
 	@Column
 	private String accessionNumber;
@@ -84,6 +86,8 @@ public class GermplasmEntity extends BrAPIPrimaryEntity {
 	private List<ObservationUnitEntity> observationUnits;
 	@ElementCollection
 	private List<GermplasmStorageTypesEnum> typeOfGermplasmStorageCode;
+	@Column(name = "soft_deleted")
+	private boolean softDeleted;
 
 	public GermplasmInstituteEntity getHostInstitute() {
 		if (getInstitutes() != null) {
@@ -351,5 +355,9 @@ public class GermplasmEntity extends BrAPIPrimaryEntity {
 	public void setTypeOfGermplasmStorageCode(List<GermplasmStorageTypesEnum> typeOfGermplasmStorageCode) {
 		this.typeOfGermplasmStorageCode = typeOfGermplasmStorageCode;
 	}
+
+	public boolean getSoftDeleted() { return softDeleted; }
+
+	public void setSoftDeleted(boolean sofDeleted) { this.softDeleted = sofDeleted; }
 
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeEdgeEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeEdgeEntity.java
@@ -12,7 +12,7 @@ public class PedigreeEdgeEntity extends BrAPIPrimaryEntity{
 	@ManyToOne(fetch = FetchType.LAZY)
 	private PedigreeNodeEntity thisNode;
 	@ManyToOne(fetch = FetchType.LAZY)
-	private PedigreeNodeEntity conncetedNode;
+	private PedigreeNodeEntity connectedNode;
 	@Column
 	private ParentType parentType;
 	@Column
@@ -31,11 +31,11 @@ public class PedigreeEdgeEntity extends BrAPIPrimaryEntity{
 	public void setEdgeType(EdgeType edgeType) {
 		this.edgeType = edgeType;
 	}
-	public PedigreeNodeEntity getConncetedNode() {
-		return conncetedNode;
+	public PedigreeNodeEntity getConnectedNode() {
+		return connectedNode;
 	}
-	public void setConncetedNode(PedigreeNodeEntity conncetedNode) {
-		this.conncetedNode = conncetedNode;
+	public void setConnectedNode(PedigreeNodeEntity connectedNode) {
+		this.connectedNode = connectedNode;
 	}
 	public ParentType getParentType() {
 		return parentType;

--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/germ/PedigreeNodeEntity.java
@@ -94,7 +94,7 @@ public class PedigreeNodeEntity extends BrAPIPrimaryEntity {
 	public List<PedigreeNodeEntity> getParentNodes() {
 		return edges.stream().filter(e -> {
 			return e.getEdgeType() == EdgeType.parent;
-		}).map(edge -> edge.getConncetedNode()).collect(Collectors.toList());
+		}).map(edge -> edge.getConnectedNode()).collect(Collectors.toList());
 	}
 
 	public List<PedigreeEdgeEntity> getProgenyEdges() {
@@ -106,13 +106,13 @@ public class PedigreeNodeEntity extends BrAPIPrimaryEntity {
 	public List<PedigreeNodeEntity> getProgenyNodes() {
 		return edges.stream().filter(e -> {
 			return e.getEdgeType() == EdgeType.child;
-		}).map(edge -> edge.getConncetedNode()).collect(Collectors.toList());
+		}).map(edge -> edge.getConnectedNode()).collect(Collectors.toList());
 	}
 
 	public void addParent(PedigreeNodeEntity node, ParentType type) {
 		PedigreeEdgeEntity edge = new PedigreeEdgeEntity();
 		edge.setThisNode(this);
-		edge.setConncetedNode(node);
+		edge.setConnectedNode(node);
 		edge.setParentType(type);
 		edge.setEdgeType(EdgeType.parent);
 		if(edges == null) 
@@ -123,7 +123,7 @@ public class PedigreeNodeEntity extends BrAPIPrimaryEntity {
 	public void addProgeny(PedigreeNodeEntity node, ParentType type) {
 		PedigreeEdgeEntity edge = new PedigreeEdgeEntity();
 		edge.setThisNode(this);
-		edge.setConncetedNode(node);
+		edge.setConnectedNode(node);
 		edge.setParentType(type);
 		edge.setEdgeType(EdgeType.child);
 		if(edges == null) 

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
@@ -2,7 +2,21 @@ package org.brapi.test.BrAPITestServer.repository.germ;
 
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
 import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface GermplasmRepository extends BrAPIRepository<GermplasmEntity, String> {
+    @Modifying
+    @Transactional
+    @Query("UPDATE GermplasmEntity g SET g.softDeleted = :softDeleted WHERE g.id = :germplasmId")
+    int updateSoftDeletedStatus(@Param("germplasmId") String listId, @Param("softDeleted") boolean softDeleted);
 
+    @Modifying
+    @Transactional
+    @Query("UPDATE GermplasmEntity g SET g.softDeleted = :softDeleted WHERE g.id IN :germplasmIds")
+    int updateSoftDeletedStatusBatch(@Param("germplasmIds") List<String> germplasmIds, @Param("softDeleted") boolean softDeleted);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/PedigreeRepositoryCustomImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/PedigreeRepositoryCustomImpl.java
@@ -17,9 +17,9 @@ public class PedigreeRepositoryCustomImpl implements PedigreeRepositoryCustom {
 	public List<PedigreeNodeEntity> findPedigreeSiblings(PedigreeNodeEntity sourceNode) {
 		String siblingSearchSQL = "select distinct siblingNode from PedigreeNodeEntity siblingNode "
 				+ "join siblingNode.edges parentEdge "
-				+ "join parentEdge.conncetedNode.edges childEdge "
-				+ "join childEdge.conncetedNode sourceNode "
-				+ "where sourceNode = :sourceId and parentEdge.edgeType = 0 and childEdge.edgeType = 1 and siblingNode.id != childEdge.conncetedNode.id";
+				+ "join parentEdge.connectedNode.edges childEdge "
+				+ "join childEdge.connectedNode sourceNode "
+				+ "where sourceNode = :sourceId and parentEdge.edgeType = 0 and childEdge.edgeType = 1 and siblingNode.id != childEdge.connectedNode.id";
 		
 		TypedQuery<PedigreeNodeEntity> query = em.createQuery(siblingSearchSQL, PedigreeNodeEntity.class);
 		query.setParameter("sourceId", sourceNode);

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -277,7 +277,7 @@ public class GermplasmService {
 		searchQuery.leftJoinFetch("pedigree", "pedigree")
 				   .leftJoinFetch("*pedigree.crossingProject", "crossingProject")
 				   .leftJoinFetch("*pedigree.edges", "pedigreeEdges")
-				   .leftJoinFetch("*pedigreeEdges.conncetedNode", "connectedNode")
+				   .leftJoinFetch("*pedigreeEdges.connectedNode", "connectedNode")
 				   .appendList(page.stream()
 								   .map(BrAPIBaseEntity::getId)
 								   .collect(Collectors.toList()), "id");
@@ -324,6 +324,29 @@ public class GermplasmService {
 		GermplasmEntity savedEntity = germplasmRepository.saveAndFlush(entity);
 
 		return convertFromEntity(savedEntity);
+	}
+
+	public void deleteGermplasmBatch(List<String> germplasmDbIds) {
+		germplasmRepository.deleteAllByIdInBatch(germplasmDbIds);
+	}
+
+	public void softDeleteGermplasmBatch(List<String> germplasmDbIds) {
+		germplasmRepository.updateSoftDeletedStatusBatch(germplasmDbIds, true);
+	}
+
+	public void deleteGermplasm(String germplasmDbId) throws BrAPIServerException {
+		// Soft delete the germplasm first since the method throws a 404 exception if the germplasm is not found
+		softDeleteGermplasm(germplasmDbId);
+
+		// Hard delete the list
+		germplasmRepository.deleteAllByIdInBatch(Arrays.asList(germplasmDbId));
+	}
+
+	public void softDeleteGermplasm(String germplasmDbId) throws BrAPIServerException {
+		int updatedCount = germplasmRepository.updateSoftDeletedStatus(germplasmDbId, true);
+		if (updatedCount == 0) {
+			throw new BrAPIServerDbIdNotFoundException("list", germplasmDbId, "list database ID", HttpStatus.NOT_FOUND);
+		}
 	}
 
 	public List<Germplasm> saveGermplasm(@Valid List<GermplasmNewRequest> body) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -17,7 +17,6 @@ import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.germ.CrossingProjectEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.PedigreeEdgeEntity;
-import org.brapi.test.BrAPITestServer.model.entity.germ.PedigreeEdgeEntity.EdgeType;
 import org.brapi.test.BrAPITestServer.model.entity.germ.PedigreeNodeEntity;
 import org.brapi.test.BrAPITestServer.repository.germ.PedigreeEdgeRepository;
 import org.brapi.test.BrAPITestServer.repository.germ.PedigreeRepository;
@@ -408,8 +407,8 @@ public class PedigreeService {
 			if (entity.getParentEdges() != null && request.isIncludeParents()) {
 				node.setParents(entity.getParentEdges().stream().map(edge -> {
 					PedigreeNodeParents parent = new PedigreeNodeParents();
-					parent.setGermplasmDbId(edge.getConncetedNode().getGermplasm().getId());
-					parent.setGermplasmName(edge.getConncetedNode().getGermplasm().getGermplasmName());
+					parent.setGermplasmDbId(edge.getConnectedNode().getGermplasm().getId());
+					parent.setGermplasmName(edge.getConnectedNode().getGermplasm().getGermplasmName());
 					parent.setParentType(edge.getParentType());
 					return parent;
 				}).collect(Collectors.toList()));
@@ -417,8 +416,8 @@ public class PedigreeService {
 			if (entity.getProgenyEdges() != null && request.isIncludeProgeny()) {
 				node.setProgeny(entity.getProgenyEdges().stream().map(edge -> {
 					PedigreeNodeParents progeny = new PedigreeNodeParents();
-					progeny.setGermplasmDbId(edge.getConncetedNode().getGermplasm().getId());
-					progeny.setGermplasmName(edge.getConncetedNode().getGermplasm().getGermplasmName());
+					progeny.setGermplasmDbId(edge.getConnectedNode().getGermplasm().getId());
+					progeny.setGermplasmName(edge.getConnectedNode().getGermplasm().getGermplasmName());
 					progeny.setParentType(edge.getParentType());
 					return progeny;
 				}).collect(Collectors.toList()));
@@ -442,10 +441,10 @@ public class PedigreeService {
 			if (entity.getParentEdges() != null && !entity.getParentEdges().isEmpty()) {
 				Optional<PedigreeNodeEntity> mother = entity.getParentEdges().stream().filter(parentEdge -> {
 					return ParentType.FEMALE == parentEdge.getParentType();
-				}).map(PedigreeEdgeEntity::getConncetedNode).findFirst();
+				}).map(PedigreeEdgeEntity::getConnectedNode).findFirst();
 				Optional<PedigreeNodeEntity> father = entity.getParentEdges().stream().filter(parentEdge -> {
 					return ParentType.MALE == parentEdge.getParentType();
-				}).map(PedigreeEdgeEntity::getConncetedNode).findFirst();
+				}).map(PedigreeEdgeEntity::getConnectedNode).findFirst();
 
 				if (mother.isPresent()) {
 					pedStr += mother.get().getGermplasm().getGermplasmName() + "/";
@@ -493,7 +492,7 @@ public class PedigreeService {
 		if (node.getParents() != null) {
 
 			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
-			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
+			search.appendSingle(node.getGermplasmDbId(), "connectedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
 			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);
@@ -516,7 +515,7 @@ public class PedigreeService {
 		if (node.getProgeny() != null) {
 
 			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
-			search.appendSingle(node.getGermplasmDbId(), "conncetedNode.germplasm.id");
+			search.appendSingle(node.getGermplasmDbId(), "connectedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
 			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search, defaultPageSize);

--- a/src/main/resources/db/migration/V002.014__add_soft_deleted_column_to_germplasm.sql
+++ b/src/main/resources/db/migration/V002.014__add_soft_deleted_column_to_germplasm.sql
@@ -1,0 +1,574 @@
+-- Add soft_deleted column to germplasm
+ALTER TABLE public.germplasm
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_attribute_value
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_attribute_value_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_donor
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_donor_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_entity_type_of_germplasm_storage_code
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_institute
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_origin
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_search_results
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_synonym
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.germplasm_taxon
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.pedigree_node
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.pedigree_node_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.pedigree_edge
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.pedigree_edge_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.cross_parent
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'observation_unit'
+          AND table_schema = 'public'
+          AND column_name = 'soft_deleted'
+    ) THEN
+ALTER TABLE public.observation_unit
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+END IF;
+END $$;
+
+ALTER TABLE public.observation_unit_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.observation_unit_level
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.observation_unit_position
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.observation_unit_treatment
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.event_observation_units
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'observation'
+          AND table_schema = 'public'
+          AND column_name = 'soft_deleted'
+    ) THEN
+ALTER TABLE public.observation
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+END IF;
+END $$;
+
+ALTER TABLE public.image
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.image_entity_descriptive_ontology_terms
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.image_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.image_observations
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference_set
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference_set_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference_bases
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference_bases_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.reference_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.seed_lot_content_mixture
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant_entity_alternate_bases
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant_entity_ciend
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant_entity_cipos
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variant_entity_filters_failed
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variantset
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variantset_analysis
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variantset_external_references
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.variantset_format
+    ADD COLUMN soft_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Create a trigger function to update soft_deleted status for records with germplasm foreign key
+CREATE OR REPLACE FUNCTION sync_germplasm_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update germplasm_external_references
+UPDATE public.germplasm_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_entity_id = NEW.id;
+
+-- Update germplasm_attribute_value
+UPDATE public.germplasm_attribute_value
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update germplasm_donor
+UPDATE public.germplasm_donor
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update germplasm_entity_type_of_germplasm_storage_code
+UPDATE public.germplasm_entity_type_of_germplasm_storage_code
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_entity_id = NEW.id;
+
+-- Update germplasm_institute
+UPDATE public.germplasm_institute
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update germplasm_origin
+UPDATE public.germplasm_origin
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update germplasm_search_results
+UPDATE public.germplasm_search_results
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_entity_id = NEW.id;
+
+-- Update germplasm_synonyms
+UPDATE public.germplasm_synonym
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update germplasm_taxon
+UPDATE public.germplasm_taxon
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update pedigree_node
+UPDATE public.pedigree_node
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update cross_parent
+UPDATE public.cross_parent
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update observation_unit
+UPDATE public.observation_unit
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+-- Update reference_set
+UPDATE public.reference_set
+SET soft_deleted = NEW.soft_deleted
+WHERE source_germplasm_id = NEW.id;
+
+-- Update seed_lot_content_mixture
+UPDATE public.seed_lot_content_mixture
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with germplasm_attribute_value foreign key
+CREATE OR REPLACE FUNCTION sync_germplasm_attribute_value_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update germplasm_attribute_value_external_references
+UPDATE public.germplasm_attribute_value_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE germplasm_attribute_value_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with germplasm_donor foreign key
+CREATE OR REPLACE FUNCTION sync_germplasm_donor_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update germplasm_donor_external_references
+UPDATE public.germplasm_donor_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE donor_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with pedigree_node foreign key
+CREATE OR REPLACE FUNCTION sync_pedigree_node_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update pedigree_node_external_references
+UPDATE public.pedigree_node_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE pedigree_node_entity_id = NEW.id;
+
+-- Update pedigree_edge
+UPDATE public.pedigree_edge
+SET soft_deleted = NEW.soft_deleted
+WHERE connected_node_id = NEW.id;
+
+-- Update pedigree_edge
+UPDATE public.pedigree_edge
+SET soft_deleted = NEW.soft_deleted
+WHERE this_node_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with pedigree_edge foreign key
+CREATE OR REPLACE FUNCTION sync_pedigree_edge_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update pedigree_edge_external_references
+UPDATE public.pedigree_edge_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE pedigree_edge_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with observation_unit foreign key
+CREATE OR REPLACE FUNCTION sync_observation_unit_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update observation_unit_external_references
+UPDATE public.observation_unit_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_entity_id = NEW.id;
+
+-- Update observation
+UPDATE public.observation
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_id = NEW.id;
+
+-- Update observation_unit_level
+UPDATE public.observation_unit_level
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_id = NEW.id;
+
+-- Update observation_unit_position
+UPDATE public.observation_unit_position
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_id = NEW.id;
+
+-- Update observation_unit_treatment
+UPDATE public.observation_unit_treatment
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_id = NEW.id;
+
+-- Update event_observation_units
+UPDATE public.event_observation_units
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_units_id = NEW.id;
+
+-- Update image
+UPDATE public.image
+SET soft_deleted = NEW.soft_deleted
+WHERE observation_unit_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with image foreign key
+CREATE OR REPLACE FUNCTION sync_image_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update image_entity_descriptive_ontology_terms
+UPDATE public.image_entity_descriptive_ontology_terms
+SET soft_deleted = NEW.soft_deleted
+WHERE image_entity_id = NEW.id;
+
+-- Update image_external_references
+UPDATE public.image_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE image_entity_id = NEW.id;
+
+-- Update image_observations
+UPDATE public.image_observations
+SET soft_deleted = NEW.soft_deleted
+WHERE image_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with reference_set foreign key
+CREATE OR REPLACE FUNCTION sync_reference_set_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update reference_set_external_references
+UPDATE public.reference_set_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_set_entity_id = NEW.id;
+
+-- Update reference
+UPDATE public.reference
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_set_id = NEW.id;
+
+-- Update variant
+UPDATE public.variant
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_set_id = NEW.id;
+
+-- Update variantset
+UPDATE public.variantset
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_set_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with reference foreign key
+CREATE OR REPLACE FUNCTION sync_reference_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update reference_bases
+UPDATE public.reference_bases
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_id = NEW.id;
+
+-- Update reference_external_references
+UPDATE public.reference_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with reference_bases foreign key
+CREATE OR REPLACE FUNCTION sync_reference_bases_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update reference_bases_external_references
+UPDATE public.reference_bases_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE reference_bases_page_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with variant foreign key
+CREATE OR REPLACE FUNCTION sync_variant_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update variant_external_references
+UPDATE public.variant_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_entity_id = NEW.id;
+
+-- Update variant_entity_alternate_bases
+UPDATE public.variant_entity_alternate_bases
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_entity_id = NEW.id;
+
+-- Update variant_entity_ciend
+UPDATE public.variant_entity_ciend
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_entity_id = NEW.id;
+
+-- Update variant_entity_cipos
+UPDATE public.variant_entity_cipos
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_entity_id = NEW.id;
+
+-- Update variant_entity_filters_failed
+UPDATE public.variant_entity_filters_failes
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_entity_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger function to update soft_deleted status for records with variantset foreign key
+CREATE OR REPLACE FUNCTION sync_variantset_related_tables_soft_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+-- Update variantset_analysis
+UPDATE public.variantset_analysis
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_set_id = NEW.id;
+
+-- Update variantset_external_references
+UPDATE public.variantset_external_references
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_set_entity_id = NEW.id;
+
+-- Update variantset_format
+UPDATE public.variantset_format
+SET soft_deleted = NEW.soft_deleted
+WHERE variant_set_id = NEW.id;
+
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create a trigger on the germplasm table
+CREATE TRIGGER sync_germplasm_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.germplasm
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_germplasm_related_tables_soft_deleted();
+
+-- Create a trigger on the germplasm_attribute_value table
+CREATE TRIGGER sync_germplasm_attribute_value_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.germplasm_attribute_value
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_germplasm_attribute_value_related_tables_soft_deleted();
+
+-- Create a trigger on the germplasm_donor table
+CREATE TRIGGER sync_germplasm_donor_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.germplasm_donor
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_germplasm_donor_related_tables_soft_deleted();
+
+-- Create a trigger on the pedigree_node table
+CREATE TRIGGER sync_pedigree_node_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.pedigree_node
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_pedigree_node_related_tables_soft_deleted();
+
+-- Create a trigger on the pedigree_edge table
+CREATE TRIGGER sync_pedigree_edge_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.pedigree_edge
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_pedigree_edge_related_tables_soft_deleted();
+
+-- Create a trigger on the observation_unit table
+CREATE TRIGGER sync_observation_unit_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.observation_unit
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_observation_unit_related_tables_soft_deleted();
+
+-- Create a trigger on the image table
+CREATE TRIGGER sync_image_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.image
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_image_related_tables_soft_deleted();
+
+-- Create a trigger on the reference_set table
+CREATE TRIGGER sync_reference_set_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.reference_set
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_reference_set_related_tables_soft_deleted();
+
+-- Create a trigger on the reference table
+CREATE TRIGGER sync_reference_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.reference
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_reference_related_tables_soft_deleted();
+
+-- Create a trigger on the reference table
+CREATE TRIGGER sync_reference_bases_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.reference_bases
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_reference_bases_related_tables_soft_deleted();
+
+-- Create a trigger on the variant table
+CREATE TRIGGER sync_variant_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.variant
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_variant_related_tables_soft_deleted();
+
+-- Create a trigger on the variantset table
+CREATE TRIGGER sync_variantset_soft_deleted_status
+    AFTER UPDATE OF soft_deleted ON public.variantset
+    FOR EACH ROW
+    WHEN (OLD.soft_deleted IS DISTINCT FROM NEW.soft_deleted)
+EXECUTE FUNCTION sync_variantset_related_tables_soft_deleted();

--- a/src/main/resources/db/migration/V002.015__cascade_delete_germplasm.sql
+++ b/src/main/resources/db/migration/V002.015__cascade_delete_germplasm.sql
@@ -1,0 +1,375 @@
+-- This migration will delete records associated with a deleted germplasm
+
+-- First, drop the existing foreign key constraint
+ALTER TABLE ONLY public.germplasm_external_references
+DROP CONSTRAINT IF EXISTS fkibd3k0wfmkkjf2budoeothsub;
+
+ALTER TABLE ONLY public.germplasm_attribute_value
+DROP CONSTRAINT IF EXISTS fkqqry5v3us53yf0o4dlcd7dxg8;
+
+ALTER TABLE ONLY public.germplasm_donor
+DROP CONSTRAINT IF EXISTS fk6e02we60r9ut32qqhxb86ca72;
+
+ALTER TABLE ONLY public.germplasm_entity_type_of_germplasm_storage_code
+DROP CONSTRAINT IF EXISTS fktahnvan5u79myt3kbqkijra78;
+
+ALTER TABLE ONLY public.germplasm_institute
+DROP CONSTRAINT IF EXISTS fkk9yp3d2siqb14sw6gvvrcspo6;
+
+ALTER TABLE ONLY public.germplasm_origin
+DROP CONSTRAINT IF EXISTS fk1m54g844qt69f241brkregk05;
+
+ALTER TABLE ONLY public.germplasm_search_results
+DROP CONSTRAINT IF EXISTS fk6ett5g30uvf3d4101e7ndoj8c;
+
+ALTER TABLE ONLY public.germplasm_synonym
+DROP CONSTRAINT IF EXISTS fkkm9j9i32axrnrs34qr9q6a63n;
+
+ALTER TABLE ONLY public.germplasm_taxon
+DROP CONSTRAINT IF EXISTS fkokfpuhyosimp5gdloucr73vja;
+
+ALTER TABLE ONLY public.pedigree_node
+DROP CONSTRAINT IF EXISTS fkkll27h6pngksanbpu2dnnldbt;
+
+ALTER TABLE ONLY public.cross_parent
+DROP CONSTRAINT IF EXISTS fkgwne8ni7iqgxeu5qvnjskbkvj;
+
+ALTER TABLE ONLY public.observation_unit
+DROP CONSTRAINT IF EXISTS fkgykwn3x9wx8m77wy67juqlxab;
+
+ALTER TABLE ONLY public.reference_set
+DROP CONSTRAINT IF EXISTS fko1ndd24soyk8191bqhg7fegdg;
+
+ALTER TABLE ONLY public.seed_lot_content_mixture
+DROP CONSTRAINT IF EXISTS fkc1gnrmj6ceuu1o4s6ffs4yjt3;
+
+ALTER TABLE ONLY public.pedigree_edge
+DROP CONSTRAINT IF EXISTS fk89pdbyb8xx3eua9b9i5cu5ltq;
+
+ALTER TABLE ONLY public.pedigree_edge
+DROP CONSTRAINT IF EXISTS fk5ds4uo4f3tsurnjtc8dxb7w6r;
+
+ALTER TABLE ONLY public.pedigree_edge_external_references
+DROP CONSTRAINT IF EXISTS fk8b66j4ff2axcsuosr5erotn8e;
+
+ALTER TABLE ONLY public.observation_unit_external_references
+DROP CONSTRAINT IF EXISTS fkel9v1egnbmp20dpbkt1831ljq;
+
+ALTER TABLE ONLY public.observation
+DROP CONSTRAINT IF EXISTS fkfqw685lfh2uxxbgi60vne24jr;
+
+ALTER TABLE ONLY public.observation_unit_level
+DROP CONSTRAINT IF EXISTS fk8iqhtkmddjbc4vhhf26ayx3b4;
+
+ALTER TABLE ONLY public.observation_unit_position
+DROP CONSTRAINT IF EXISTS fk2mpgvaq1ppb8kjp3jk0ecpdyr;
+
+ALTER TABLE ONLY public.observation_unit_treatment
+DROP CONSTRAINT IF EXISTS fk9aok9thr8d6dgqveur46e5985;
+
+ALTER TABLE ONLY public.event_observation_units
+DROP CONSTRAINT IF EXISTS fk3ecq9fb2rd3qampc61hunr7sw;
+
+ALTER TABLE ONLY public.image
+DROP CONSTRAINT IF EXISTS fkob3t0l8jr07byg0p3vd06yig4;
+
+ALTER TABLE ONLY public.image_entity_descriptive_ontology_terms
+DROP CONSTRAINT IF EXISTS fkce2lade5kp0pnd7dkps05s494;
+
+ALTER TABLE ONLY public.image_external_references
+DROP CONSTRAINT IF EXISTS fkt3uy354jynflg06911dxjlu1i;
+
+ALTER TABLE ONLY public.image_observations
+DROP CONSTRAINT IF EXISTS fkbwiawjcj7mihofl5puuq7k2ws;
+
+ALTER TABLE ONLY public.reference_set_external_references
+DROP CONSTRAINT IF EXISTS fkbk2b1k68f0drytr6pkncudxoh;
+
+ALTER TABLE ONLY public.reference
+DROP CONSTRAINT IF EXISTS fkpr6hqcaxgwgl0uom9wo22om65;
+
+ALTER TABLE ONLY public.variant
+DROP CONSTRAINT IF EXISTS fkh523hkn6t8iurf19bb19o7px7;
+
+ALTER TABLE ONLY public.variantset
+DROP CONSTRAINT IF EXISTS fkoy17h5s7f83vl8rfcpeqduhp3;
+
+ALTER TABLE ONLY public.reference_bases
+DROP CONSTRAINT IF EXISTS fkro4r722mjgl8huj88soea80le;
+
+ALTER TABLE ONLY public.reference_external_references
+DROP CONSTRAINT IF EXISTS fkr0nxjwbpehkbp8vfg3xyql5vy;
+
+ALTER TABLE ONLY public.reference_bases_external_references
+DROP CONSTRAINT IF EXISTS fkf6sny2j9k3hugyrp6iut22oo;
+
+ALTER TABLE ONLY public.variant_external_references
+DROP CONSTRAINT IF EXISTS fkgoibfri9bvwfh4jd8snqwcw5u;
+
+ALTER TABLE ONLY public.variant_entity_alternate_bases
+DROP CONSTRAINT IF EXISTS fkv6ptn907aedytbh5w8mc6t3r;
+
+ALTER TABLE ONLY public.variant_entity_ciend
+DROP CONSTRAINT IF EXISTS fk9dsm85o8qltahmd03symbgohp;
+
+ALTER TABLE ONLY public.variant_entity_cipos
+DROP CONSTRAINT IF EXISTS fkh94uec6mbay6eld1uxk1m2xbi;
+
+ALTER TABLE ONLY public.variant_entity_filters_failed
+DROP CONSTRAINT IF EXISTS fki10kljn84l12s881v3bxdh34n;
+
+ALTER TABLE ONLY public.variantset_analysis
+DROP CONSTRAINT IF EXISTS fko9jtegpt029eaca8mifd8yrm4;
+
+ALTER TABLE ONLY public.variantset_external_references
+DROP CONSTRAINT IF EXISTS fkckhrweboc7ktl0e7obei7731f;
+
+ALTER TABLE ONLY public.variantset_format
+DROP CONSTRAINT IF EXISTS fkse2qx2lkfhnb00nnoexcpa1fu;
+
+-- Then, recreate the constraint with ON DELETE CASCADE
+ALTER TABLE ONLY public.variantset_format
+    ADD CONSTRAINT fkse2qx2lkfhnb00nnoexcpa1fu
+    FOREIGN KEY (variant_set_id)
+    REFERENCES public.variantset(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variantset_external_references
+    ADD CONSTRAINT fkckhrweboc7ktl0e7obei7731f
+    FOREIGN KEY (variant_set_entity_id)
+    REFERENCES public.variantset(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variantset_analysis
+    ADD CONSTRAINT fko9jtegpt029eaca8mifd8yrm4
+    FOREIGN KEY (variant_set_id)
+    REFERENCES public.variantset(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant_entity_filters_failed
+    ADD CONSTRAINT fki10kljn84l12s881v3bxdh34n
+    FOREIGN KEY (variant_entity_id)
+    REFERENCES public.variant(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant_entity_cipos
+    ADD CONSTRAINT fkh94uec6mbay6eld1uxk1m2xbi
+    FOREIGN KEY (variant_entity_id)
+    REFERENCES public.variant(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant_entity_ciend
+    ADD CONSTRAINT fk9dsm85o8qltahmd03symbgohp
+    FOREIGN KEY (variant_entity_id)
+    REFERENCES public.variant(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant_entity_alternate_bases
+    ADD CONSTRAINT fkv6ptn907aedytbh5w8mc6t3r
+    FOREIGN KEY (variant_entity_id)
+    REFERENCES public.variant(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant_external_references
+    ADD CONSTRAINT fkgoibfri9bvwfh4jd8snqwcw5u
+    FOREIGN KEY (variant_entity_id)
+    REFERENCES public.variant(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference_bases_external_references
+    ADD CONSTRAINT fkf6sny2j9k3hugyrp6iut22oo
+    FOREIGN KEY (reference_bases_page_entity_id)
+    REFERENCES public.reference_bases(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference_external_references
+    ADD CONSTRAINT fkr0nxjwbpehkbp8vfg3xyql5vy
+    FOREIGN KEY (reference_entity_id)
+    REFERENCES public.reference(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference_bases
+    ADD CONSTRAINT fkro4r722mjgl8huj88soea80le
+    FOREIGN KEY (reference_id)
+    REFERENCES public.reference(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variantset
+    ADD CONSTRAINT fkoy17h5s7f83vl8rfcpeqduhp3
+    FOREIGN KEY (reference_set_id)
+    REFERENCES public.reference_set(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.variant
+    ADD CONSTRAINT fkh523hkn6t8iurf19bb19o7px7
+    FOREIGN KEY (reference_set_id)
+    REFERENCES public.reference_set(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference
+    ADD CONSTRAINT fkpr6hqcaxgwgl0uom9wo22om65
+    FOREIGN KEY (reference_set_id)
+    REFERENCES public.reference_set(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference_set_external_references
+    ADD CONSTRAINT fkbk2b1k68f0drytr6pkncudxoh
+    FOREIGN KEY (reference_set_entity_id)
+    REFERENCES public.reference_set(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.image_observations
+    ADD CONSTRAINT fkbwiawjcj7mihofl5puuq7k2ws
+    FOREIGN KEY (image_entity_id)
+    REFERENCES public.image(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.image_external_references
+    ADD CONSTRAINT fkt3uy354jynflg06911dxjlu1i
+    FOREIGN KEY (image_entity_id)
+    REFERENCES public.image(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.image_entity_descriptive_ontology_terms
+    ADD CONSTRAINT fkce2lade5kp0pnd7dkps05s494
+    FOREIGN KEY (image_entity_id)
+    REFERENCES public.image(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.image
+    ADD CONSTRAINT fkob3t0l8jr07byg0p3vd06yig4
+    FOREIGN KEY (observation_unit_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.event_observation_units
+    ADD CONSTRAINT fk3ecq9fb2rd3qampc61hunr7sw
+    FOREIGN KEY (observation_units_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation_unit_treatment
+    ADD CONSTRAINT fk9aok9thr8d6dgqveur46e5985
+    FOREIGN KEY (observation_unit_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation_unit_position
+    ADD CONSTRAINT fk2mpgvaq1ppb8kjp3jk0ecpdyr
+    FOREIGN KEY (observation_unit_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation_unit_level
+    ADD CONSTRAINT fk8iqhtkmddjbc4vhhf26ayx3b4
+    FOREIGN KEY (observation_unit_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation
+    ADD CONSTRAINT fkfqw685lfh2uxxbgi60vne24jr
+    FOREIGN KEY (observation_unit_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation_unit_external_references
+    ADD CONSTRAINT fkel9v1egnbmp20dpbkt1831ljq
+    FOREIGN KEY (observation_unit_entity_id)
+    REFERENCES public.observation_unit(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.pedigree_edge_external_references
+    ADD CONSTRAINT fk8b66j4ff2axcsuosr5erotn8e
+    FOREIGN KEY (pedigree_edge_entity_id)
+    REFERENCES public.pedigree_edge(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.pedigree_edge
+    ADD CONSTRAINT fk89pdbyb8xx3eua9b9i5cu5ltq
+    FOREIGN KEY (this_node_id)
+    REFERENCES public.pedigree_node(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.seed_lot_content_mixture
+    ADD CONSTRAINT fkc1gnrmj6ceuu1o4s6ffs4yjt3
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.reference_set
+    ADD CONSTRAINT fko1ndd24soyk8191bqhg7fegdg
+    FOREIGN KEY (source_germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.observation_unit
+    ADD CONSTRAINT fkgykwn3x9wx8m77wy67juqlxab
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.cross_parent
+    ADD CONSTRAINT fkgwne8ni7iqgxeu5qvnjskbkvj
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.pedigree_node
+    ADD CONSTRAINT fkkll27h6pngksanbpu2dnnldbt
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_taxon
+    ADD CONSTRAINT fkokfpuhyosimp5gdloucr73vja
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_synonym
+    ADD CONSTRAINT fkkm9j9i32axrnrs34qr9q6a63n
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_search_results
+    ADD CONSTRAINT fk6ett5g30uvf3d4101e7ndoj8c
+    FOREIGN KEY (germplasm_entity_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_origin
+    ADD CONSTRAINT fk1m54g844qt69f241brkregk05
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_institute
+    ADD CONSTRAINT fkk9yp3d2siqb14sw6gvvrcspo6
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_entity_type_of_germplasm_storage_code
+    ADD CONSTRAINT fktahnvan5u79myt3kbqkijra78
+    FOREIGN KEY (germplasm_entity_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_external_references
+    ADD CONSTRAINT fkibd3k0wfmkkjf2budoeothsub
+    FOREIGN KEY (germplasm_entity_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_attribute_value
+    ADD CONSTRAINT fkqqry5v3us53yf0o4dlcd7dxg8
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.germplasm_donor
+    ADD CONSTRAINT fk6e02we60r9ut32qqhxb86ca72
+    FOREIGN KEY (germplasm_id)
+    REFERENCES public.germplasm(id)
+    ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V002.016__fix_pedigree_edge_typo.sql
+++ b/src/main/resources/db/migration/V002.016__fix_pedigree_edge_typo.sql
@@ -1,0 +1,23 @@
+-- V2__fix_typo_in_column_name.sql
+-- Flyway migration script to fix the typo in the column name "connceted_node_id"
+
+-- Rename the column
+ALTER TABLE public.pedigree_edge
+    RENAME COLUMN connceted_node_id TO connected_node_id;
+
+-- Drop the old index (it references the old column name)
+DROP INDEX IF EXISTS public.pedigree_edge_connected_node_id;
+
+-- Recreate the index with the correct column name
+CREATE INDEX pedigree_edge_connected_node_id ON public.pedigree_edge USING btree (connected_node_id);
+
+-- Drop the old foreign key constraint (it references the old column name)
+ALTER TABLE ONLY public.pedigree_edge
+DROP CONSTRAINT IF EXISTS fk5ds4uo4f3tsurnjtc8dxb7w6r;
+
+-- Add a new foreign key constraint with the correct column name
+ALTER TABLE ONLY public.pedigree_edge
+    ADD CONSTRAINT fk5ds4uo4f3tsurnjtc8dxb7w6r
+    FOREIGN KEY (connected_node_id)
+    REFERENCES public.pedigree_node(id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
Story: [BI-2476](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2476)

This pull request implements a "soft delete" functionality for germplasm data, meaning that instead of permanently deleting germplasm records, they are marked as deleted. This provides a mechanism for data recovery and avoids data loss. A hard delete option is also implemented. The pull request also fixes a typo in the PedigreeEdgeEntity related to connectedNode. 

### Key Changes:
Germplasm Deletion Endpoint: Adds a new API endpoint to delete germplasm records. The endpoint supports both hard deletes (permanent deletion) and soft deletes.
    Soft Delete Implementation: Introduces a softDeleted boolean field to the GermplasmEntity to indicate whether a record has been soft deleted. The entity is also updated with a @Where clause so that only non-deleted entities are returned by default.
    Database Migration: Adds SQL migration scripts to add the soft_deleted column to the germplasm table.
    Repository Updates: The GermplasmRepository is updated with new methods to perform the soft delete.
    Controller Updates: The GermplasmApiController is updated to implement batch deletes.
    Typo Fix: Corrects a typo in the PedigreeEdgeEntity class, replacing conncetedNode with connectedNode. This change is reflected in the corresponding database migration and JPQL queries.
    Component Factory Updates: Updated the GermplasmComponent to use the correct service methods for batch soft and hard deletes.

The following associated entities will cascade delete when a germplasm record is soft- or hard-deleted:
#### Germplasm Children
- seed_lot_content_mixture 
- reference_set 
- observation_unit 
- cross_parent 
- pedigree_node 
- germplasm_taxon 
- germplasm_synonym
- germplasm_search_results 
- germplasm_origin 
- germplasm_institute 
- germplasm_entity_type_of_germplasm_storage_code 
- germplasm_external_references 
- germplasm_attribute_value
- germplasm_donor 

#### Observation Unit Children
- image
- event_observation_units
- observation_unit_treatment
- observation_unit_position
- observation_unit_level
- observation
- observation_unit_external_references

#### Image Children
-  image_observations 
-  image_external_references 
- image_entity_descriptive_ontology_terms 

#### Variant Children
- variant_entity_filters_failed 
- variant_entity_cipos 
- variant_entity_ciend 
- variant_entity_alternate_bases 
- variant_external_references 

#### Variant Set Children
- variantset_format 
- variantset_external_references 
- variantset_analysis 

#### Reference Children
- reference_external_references
- reference_bases

#### Reference Set Children
- variantset 
- variant 
- reference 
- reference_set_external_references 

#### Pedigree Node Child
-  pedigree_edge

#### Pedigree Edge Child
- pedigree_edge_external_references 

#### Reference Bases Child
- reference_bases_external_references 


 

   
    


[BI-2476]: https://breedinginsight.atlassian.net/browse/BI-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ