### PR TITLE
[BI-2585] BJTS migration fail due to DB field name change

### DIFF
--- a/src/main/resources/db/sql/R__init_data_16_pedigree.sql
+++ b/src/main/resources/db/sql/R__init_data_16_pedigree.sql
@@ -2,9 +2,9 @@ INSERT INTO pedigree_node (auth_user_id, id, crossing_year, family_code, pedigre
 INSERT INTO pedigree_node (auth_user_id, id, crossing_year, family_code, pedigree_string, crossing_project_id, germplasm_id) VALUES('anonymousUser', 'pedigree2', 2001, 'FAKEFAM', 'A2342345/A4564565', 'crossing_project1', 'germplasm2');
 INSERT INTO pedigree_node (auth_user_id, id, crossing_year, family_code, pedigree_string, crossing_project_id, germplasm_id) VALUES('anonymousUser', 'pedigree3', 2002, 'FAKEFAM', 'A0000001/A0000002', 'crossing_project1', 'germplasm3');
 
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p1_parent_p3',  0, 0,    'pedigree3', 'pedigree1');
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p3_child_p1',   1, 0,    'pedigree1', 'pedigree3');
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p2_parent_p3',  0, 1,    'pedigree3', 'pedigree2');
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p3_child_p2',   1, 1,    'pedigree2', 'pedigree3');
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p1_sibling_p2', 2, null, 'pedigree1', 'pedigree2');
-INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connceted_node_id) VALUES('p2_sibling_p1', 2, null, 'pedigree2', 'pedigree1');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p1_parent_p3',  0, 0,    'pedigree3', 'pedigree1');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p3_child_p1',   1, 0,    'pedigree1', 'pedigree3');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p2_parent_p3',  0, 1,    'pedigree3', 'pedigree2');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p3_child_p2',   1, 1,    'pedigree2', 'pedigree3');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p1_sibling_p2', 2, null, 'pedigree1', 'pedigree2');
+INSERT INTO pedigree_edge (id, edge_type, parent_type, this_node_id, connected_node_id) VALUES('p2_sibling_p1', 2, null, 'pedigree2', 'pedigree1');

--- a/src/main/resources/sql/create_indexes.sql
+++ b/src/main/resources/sql/create_indexes.sql
@@ -1,6 +1,6 @@
 -- Indexes to improve read performance of Germplasm operations.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "pedigree_edge_this_node_id" ON pedigree_edge (this_node_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "pedigree_edge_connected_node_id" ON pedigree_edge (connceted_node_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "pedigree_edge_connected_node_id" ON pedigree_edge (connected_node_id);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "pedigree_edge_edge_type" ON pedigree_edge (edge_type);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "program_external_references_program_entity_id" ON program_external_references (program_entity_id);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "external_reference_composite" ON external_reference (external_reference_source, external_reference_id);


### PR DESCRIPTION
[BI-2585](https://breedinginsight.atlassian.net/browse/BI-2585) BJTS migration fail due to DB field name change


**Action taken**
updated 'connceted_node_id' to 'connected_node_id'

[BI-2585]: https://breedinginsight.atlassian.net/browse/BI-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ