### PR TITLE
[BI-2579] Optimize Germplasm Import and Post Endpoint

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
@@ -199,7 +199,9 @@ public class GermplasmApiController extends BrAPIController implements Germplasm
 		log.debug("Request: " + request.getRequestURI());
 		validateSecurityContext(request, "ROLE_USER");
 		validateAcceptHeader(request);
+
 		List<Germplasm> data = germplasmService.saveGermplasm(body);
+		// TODO: Add short-circuit if no ped connections are sent.
 		pedigreeService.updateGermplasmPedigree(data);
 		return responseOK(new GermplasmListResponse(), new GermplasmListResponseResult(), data);
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
@@ -201,7 +201,7 @@ public class GermplasmApiController extends BrAPIController implements Germplasm
 		validateAcceptHeader(request);
 
 		List<Germplasm> data = germplasmService.saveGermplasm(body);
-		pedigreeService.updateGermplasmPedigree(data);
+		pedigreeService.updateGermplasmPedigreeForPost(data);
 		return responseOK(new GermplasmListResponse(), new GermplasmListResponseResult(), data);
 	}
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/controller/germ/GermplasmApiController.java
@@ -201,7 +201,6 @@ public class GermplasmApiController extends BrAPIController implements Germplasm
 		validateAcceptHeader(request);
 
 		List<Germplasm> data = germplasmService.saveGermplasm(body);
-		// TODO: Add short-circuit if no ped connections are sent.
 		pedigreeService.updateGermplasmPedigree(data);
 		return responseOK(new GermplasmListResponse(), new GermplasmListResponseResult(), data);
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepository.java
@@ -10,6 +10,7 @@ import org.brapi.test.BrAPITestServer.service.SearchQueryBuilder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
@@ -30,4 +31,6 @@ public interface BrAPIRepository<T extends BrAPIPrimaryEntity, ID extends Serial
 	public <S extends T> void refresh(S entity);
 
 	public void fetchXrefs(Page<T> page, Class<T> searchClass) throws InvalidPagingException;
+
+	List<T> findByIdIn(List<ID> ids);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/BrAPIRepositoryImpl.java
@@ -119,6 +119,10 @@ public class BrAPIRepositoryImpl<T extends BrAPIPrimaryEntity, ID extends Serial
 		return response;
 	}
 
+	public List<T> findByIdIn(List<ID> ids) {
+		return super.findAllById(ids);
+	}
+
 	public <S extends T> S save(S entity) {
 		entity.setAuthUserId(SecurityUtils.getCurrentUserId());
 		return super.save(entity);

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/core/CropRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/core/CropRepository.java
@@ -5,6 +5,10 @@ import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CropRepository extends BrAPIRepository<CropEntity, String>{
 	public Page<CropEntity> findByCropName(String cropName, Pageable pageRequest);
+
+	public List<CropEntity> findByCropNameIn(List<String> names);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/BreedingMethodRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/BreedingMethodRepository.java
@@ -3,6 +3,9 @@ package org.brapi.test.BrAPITestServer.repository.germ;
 import org.brapi.test.BrAPITestServer.model.entity.germ.BreedingMethodEntity;
 import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
 
-public interface BreedingMethodRepository extends BrAPIRepository<BreedingMethodEntity, String>{
+import java.util.List;
+import java.util.Set;
 
+public interface BreedingMethodRepository extends BrAPIRepository<BreedingMethodEntity, String>{
+    public List<BreedingMethodEntity> findByIdIn(List<String> id);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/BreedingMethodRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/BreedingMethodRepository.java
@@ -3,9 +3,5 @@ package org.brapi.test.BrAPITestServer.repository.germ;
 import org.brapi.test.BrAPITestServer.model.entity.germ.BreedingMethodEntity;
 import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
 
-import java.util.List;
-import java.util.Set;
-
-public interface BreedingMethodRepository extends BrAPIRepository<BreedingMethodEntity, String>{
-    public List<BreedingMethodEntity> findByIdIn(List<String> id);
+public interface BreedingMethodRepository extends BrAPIRepository<BreedingMethodEntity, String> {
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/CrossingProjectRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/CrossingProjectRepository.java
@@ -4,5 +4,4 @@ import org.brapi.test.BrAPITestServer.model.entity.germ.CrossingProjectEntity;
 import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
 
 public interface CrossingProjectRepository extends BrAPIRepository<CrossingProjectEntity, String> {
-
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
@@ -19,4 +19,8 @@ public interface GermplasmRepository extends BrAPIRepository<GermplasmEntity, St
     @Transactional
     @Query("UPDATE GermplasmEntity g SET g.softDeleted = :softDeleted WHERE g.id IN :germplasmIds")
     int updateSoftDeletedStatusBatch(@Param("germplasmIds") List<String> germplasmIds, @Param("softDeleted") boolean softDeleted);
+
+    List<GermplasmEntity> findByIdIn(List<String> ids);
+
+    List<GermplasmEntity> findByGermplasmNameIn(List<String> germplasmNames);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/GermplasmRepository.java
@@ -20,7 +20,5 @@ public interface GermplasmRepository extends BrAPIRepository<GermplasmEntity, St
     @Query("UPDATE GermplasmEntity g SET g.softDeleted = :softDeleted WHERE g.id IN :germplasmIds")
     int updateSoftDeletedStatusBatch(@Param("germplasmIds") List<String> germplasmIds, @Param("softDeleted") boolean softDeleted);
 
-    List<GermplasmEntity> findByIdIn(List<String> ids);
-
     List<GermplasmEntity> findByGermplasmNameIn(List<String> germplasmNames);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/PedigreeRepository.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/repository/germ/PedigreeRepository.java
@@ -7,4 +7,6 @@ import org.brapi.test.BrAPITestServer.repository.BrAPIRepository;
 
 public interface PedigreeRepository extends BrAPIRepository<PedigreeNodeEntity, String>, PedigreeRepositoryCustom {
 	public List<PedigreeNodeEntity> findByGermplasm_Id(String germplasmDbId);
+
+	public List<PedigreeNodeEntity> findByGermplasm_IdIn(List<String> germplasmDbIds);
 }

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/UpdateUtility.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/UpdateUtility.java
@@ -1,9 +1,13 @@
 package org.brapi.test.BrAPITestServer.service;
 
 import io.swagger.model.BrAPIDataModel;
+import io.swagger.model.ExternalReferences;
+import io.swagger.model.ExternalReferencesInner;
 import org.brapi.test.BrAPITestServer.model.entity.BrAPIPrimaryEntity;
+import org.brapi.test.BrAPITestServer.model.entity.ExternalReferenceEntity;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class UpdateUtility {
 
@@ -34,11 +38,59 @@ public class UpdateUtility {
 	}
 
 	public static <T extends BrAPIPrimaryEntity> T updateEntity(BrAPIDataModel model, T entity) {
+		updateAdditionalInfo(model, entity);
+		if (model.getExternalReferences() != null) {
+			entity.setExternalReferences(model.getExternalReferences());
+		}
+		return entity;
+	}
+
+	private static <T extends  BrAPIPrimaryEntity> void updateAdditionalInfo(BrAPIDataModel model, T entity) {
 		if (model.getAdditionalInfo() != null) {
 			entity.setAdditionalInfo(model.getAdditionalInfo());
 		}
+	}
+
+	/*
+	Call this method when external references are eagerly loaded for bulk updates to entities to ensure
+	unnecessary deletions and insertions don't occur.  This will improve performance in these use cases.
+
+	WARN: If refs aren't eagerly loaded, hibernate will generate a query on the entity.getReferences() call.  This could slow performance.
+
+	This method will check if the external references in the model already exist in the entity, and will prevent setting
+	the entity with the model's refs.
+
+	TODO: See if migrating all callers of updateEntity to this method can be done.
+	 */
+	public static <T extends BrAPIPrimaryEntity> T updateEntityCheckExRefs(BrAPIDataModel model, T entity) {
+		updateAdditionalInfo(model, entity);
 		if (model.getExternalReferences() != null) {
-			entity.setExternalReferences(model.getExternalReferences());
+
+			ExternalReferences exRefs = model.getExternalReferences();
+
+			Map<String, List<ExternalReferenceEntity>> existingRefsById =
+					entity.getExternalReferences() != null ?
+							entity.getExternalReferences().stream().collect(Collectors.groupingBy(ExternalReferenceEntity::getExternalReferenceId))
+							: Collections.emptyMap();
+
+
+			List<ExternalReferencesInner> newExRefs = exRefs.stream().filter(exRef -> {
+				List<ExternalReferenceEntity> existingEntityRefList = existingRefsById.get(exRef.getReferenceID());
+
+				if (existingEntityRefList == null || existingEntityRefList.isEmpty()) {
+					return true;
+				}
+
+				ExternalReferenceEntity existingEntityRef = existingEntityRefList.get(0);
+
+				return !existingEntityRef.getExternalReferenceSource().equals(exRef.getReferenceSource());
+			}).collect(Collectors.toList());
+
+			if (!newExRefs.isEmpty()) {
+				// Detected different ex refs than what is in the original entity. Updating entity exRefs.
+				entity.setExternalReferences(model.getExternalReferences());
+			}
+			// If there are no new exRefs no update is made.
 		}
 		return entity;
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/CropService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/CropService.java
@@ -63,6 +63,10 @@ public class CropService {
 		return entity;
 	}
 
+	public List<CropEntity> findCropsByNames(List<String> names) {
+		return cropRepository.findByCropNameIn(names);
+	}
+
 	public CropEntity saveCropEntity(String commonCropName)  throws BrAPIServerException {
 		CropEntity entity = null;
 		if (commonCropName != null) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/core/CropService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/core/CropService.java
@@ -68,7 +68,7 @@ public class CropService {
 		if (commonCropName != null) {
 			entity = new CropEntity();
 			entity.setCropName(commonCropName);
-			entity = cropRepository.saveAndFlush(entity);
+			entity = cropRepository.save(entity);
 		}
 		return entity;
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/BreedingMethodService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/BreedingMethodService.java
@@ -1,7 +1,9 @@
 package org.brapi.test.BrAPITestServer.service.germ;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
@@ -50,6 +52,10 @@ public class BreedingMethodService {
 			throw new BrAPIServerDbIdNotFoundException("breedingMethod", breedingMethodDbId, errorStatus);
 		}
 		return breedingMethodEntity;
+	}
+
+	public List<BreedingMethodEntity> findBreedingMethodsByIds(List<String> ids) {
+		return breedingMethodRepository.findByIdIn(ids);
 	}
 
 	private BreedingMethod convertFromEntity(BreedingMethodEntity entity) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
@@ -70,25 +70,8 @@ public class CrossingProjectService {
 		return crossingProjects;
 	}
 
-	public List<CrossingProjectEntity> findCrossingProjectsByIds(List<String> crossingProjectIds)
-		throws BrAPIServerException {
-		Metadata metadata = new Metadata().pagination(new IndexPagination());
-		Pageable pageReq = PagingUtility.getPageRequest(metadata);
-
-		SearchQueryBuilder<CrossingProjectEntity> searchQuery = new SearchQueryBuilder<CrossingProjectEntity>(
-				CrossingProjectEntity.class);
-
-		if (crossingProjectIds != null && !crossingProjectIds.isEmpty()) {
-			searchQuery = searchQuery.appendList(crossingProjectIds, "id");
-		}
-
-		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
-
-		if (page.hasContent()) {
-			return page.getContent();
-		}
-
-		return null;
+	public List<CrossingProjectEntity> findCrossingProjectsByIds(List<String> crossingProjectIds) {
+		return crossingProjectRepository.findByIdIn(crossingProjectIds);
 	}
 
 	public CrossingProject getCrossingProject(String crossingProjectDbId) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/CrossingProjectService.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import io.swagger.model.IndexPagination;
 import jakarta.validation.Valid;
 
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
@@ -67,6 +68,27 @@ public class CrossingProjectService {
 		}
 		PagingUtility.calculateMetaData(metadata, page);
 		return crossingProjects;
+	}
+
+	public List<CrossingProjectEntity> findCrossingProjectsByIds(List<String> crossingProjectIds)
+		throws BrAPIServerException {
+		Metadata metadata = new Metadata().pagination(new IndexPagination());
+		Pageable pageReq = PagingUtility.getPageRequest(metadata);
+
+		SearchQueryBuilder<CrossingProjectEntity> searchQuery = new SearchQueryBuilder<CrossingProjectEntity>(
+				CrossingProjectEntity.class);
+
+		if (crossingProjectIds != null && !crossingProjectIds.isEmpty()) {
+			searchQuery = searchQuery.appendList(crossingProjectIds, "id");
+		}
+
+		Page<CrossingProjectEntity> page = crossingProjectRepository.findAllBySearchAndPaginate(searchQuery, pageReq);
+
+		if (page.hasContent()) {
+			return page.getContent();
+		}
+
+		return null;
 	}
 
 	public CrossingProject getCrossingProject(String crossingProjectDbId) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -771,30 +771,13 @@ public class GermplasmService {
 		}
 	}
 
-	public List<GermplasmEntity> findByNames(List<String> germplasmNames)
-		throws BrAPIServerException {
-		GermplasmSearchRequest request = new GermplasmSearchRequest().germplasmNames(germplasmNames);
-		Metadata metadata = new Metadata().pagination(new IndexPagination());
-		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
-
-		if (page.hasContent()) {
-			return page.getContent();
-		}
-
-		return null;
+	public List<GermplasmEntity> findByNames(List<String> germplasmNames) {
+		return germplasmRepository.findByGermplasmNameIn(germplasmNames);
 	}
 
 	public List<GermplasmEntity> findByIds(List<String> germplasmDbIds)
 		throws BrAPIServerException {
-		GermplasmSearchRequest request = new GermplasmSearchRequest().germplasmDbIds(germplasmDbIds);
-		Metadata metadata = new Metadata().pagination(new IndexPagination());
-		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
-
-		if (!page.hasContent()) {
-			return null;
-		}
-
-		List<GermplasmEntity> germsFoundInDb = page.getContent();
+		List<GermplasmEntity> germsFoundInDb = germplasmRepository.findByIdIn(germplasmDbIds);
 
 		Set<String> germIdsFoundInDB = germsFoundInDb.stream()
 				.map(BrAPIBaseEntity::getId)

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -473,7 +473,7 @@ public class GermplasmService {
 			throws BrAPIServerException {
 		GermplasmEntity entity = getGermplasmEntity(germplasmDbId, HttpStatus.NOT_FOUND);
 		updateEntity(entity, body);
-		GermplasmEntity savedEntity = germplasmRepository.saveAndFlush(entity);
+		GermplasmEntity savedEntity = germplasmRepository.save(entity);
 
 		return convertFromEntity(savedEntity);
 	}
@@ -509,7 +509,7 @@ public class GermplasmService {
 			toSave.add(entity);
 		}
 		// Save batch.
-		return germplasmRepository.saveAllAndFlush(toSave)
+		return germplasmRepository.saveAll(toSave)
 				.stream()
 				.map(this::convertFromEntity)
 				.collect(Collectors.toList());
@@ -677,14 +677,42 @@ public class GermplasmService {
 		}
 	}
 
+	public List<GermplasmEntity> findByNames(List<String> germplasmNames)
+		throws BrAPIServerException {
+		GermplasmSearchRequest request = new GermplasmSearchRequest().germplasmNames(germplasmNames);
+		Metadata metadata = new Metadata().pagination(new IndexPagination());
+		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
+
+		if (page.hasContent()) {
+			return page.getContent();
+		}
+
+		return null;
+	}
+
+	// TODO: Add lookupType param to RQ Germplasm which can short-circuit all the lookup logic to only one query here.
 	public GermplasmEntity findByUnknownIdentity(String germplasmStr)
 		throws BrAPIServerException {
+
+		// First, check to see if the str provided is a real UUID.
+		boolean tryDBIdLookup = true;
+		try {
+			UUID germUUID = UUID.fromString(germplasmStr);
+		} catch (IllegalArgumentException e) {
+			tryDBIdLookup = false;
+		}
+
 		List<String> germplasmList = Arrays.asList(germplasmStr);
 		Metadata metadata = new Metadata().pagination(new IndexPagination());
 
 		// germplasmDbId
 		GermplasmSearchRequest request = new GermplasmSearchRequest().germplasmDbIds(germplasmList);
-		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
+		Page<GermplasmEntity> page = Page.empty();
+
+		if (tryDBIdLookup) {
+			page = findGermplasmEntities(request, metadata);
+		}
+
 		if (page.hasContent()) {
 			return page.getContent().get(0);
 		}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -772,7 +772,13 @@ public class GermplasmService {
 	}
 
 	public List<GermplasmEntity> findByNames(List<String> germplasmNames) {
-		return germplasmRepository.findByGermplasmNameIn(germplasmNames);
+		List<GermplasmEntity> foundGerms = new ArrayList<>();
+
+		if (!germplasmNames.isEmpty()) {
+			foundGerms = germplasmRepository.findByGermplasmNameIn(germplasmNames);
+		}
+
+		return foundGerms;
 	}
 
 	public List<GermplasmEntity> findByIds(List<String> germplasmDbIds)

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -436,7 +436,7 @@ public class GermplasmService {
 
 		List<GermplasmEntity> pedigree = germplasmRepository.findAllBySearch(searchQuery);
 
-		Map<String, PedigreeNodeEntity> pedigreeByGerm = new HashMap<>();
+ 		Map<String, PedigreeNodeEntity> pedigreeByGerm = new HashMap<>();
 		pedigree.forEach(germ -> pedigreeByGerm.put(germ.getId().toString(), germ.getPedigree()));
 
 		germEntities.forEach(germ -> {
@@ -696,11 +696,21 @@ public class GermplasmService {
 		Metadata metadata = new Metadata().pagination(new IndexPagination());
 		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
 
-		if (page.hasContent()) {
-			return page.getContent();
+		if (!page.hasContent()) {
+			return null;
 		}
 
-		return null;
+		List<GermplasmEntity> germsFoundInDb = page.getContent();
+
+		Set<String> germIdsFoundInDB = germsFoundInDb.stream()
+				.map(BrAPIBaseEntity::getId)
+				.collect(Collectors.toSet());
+
+		if (!germIdsFoundInDB.containsAll(germplasmDbIds)) {
+			throw new BrAPIServerDbIdNotFoundException("Germplasm Ids passed to findByIds were not found in the DB", HttpStatus.BAD_REQUEST);
+		}
+
+		return germsFoundInDb;
 	}
 
 	// TODO: Add lookupType param to RQ Germplasm which can short-circuit all the lookup logic to only one query here.

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -690,6 +690,19 @@ public class GermplasmService {
 		return null;
 	}
 
+	public List<GermplasmEntity> findByIds(List<String> germplasmDbIds)
+		throws BrAPIServerException {
+		GermplasmSearchRequest request = new GermplasmSearchRequest().germplasmDbIds(germplasmDbIds);
+		Metadata metadata = new Metadata().pagination(new IndexPagination());
+		Page<GermplasmEntity> page = findGermplasmEntities(request, metadata);
+
+		if (page.hasContent()) {
+			return page.getContent();
+		}
+
+		return null;
+	}
+
 	// TODO: Add lookupType param to RQ Germplasm which can short-circuit all the lookup logic to only one query here.
 	public GermplasmEntity findByUnknownIdentity(String germplasmStr)
 		throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -502,14 +502,8 @@ public class GermplasmService {
 	}
 
 	public List<Germplasm> saveGermplasm(@Valid List<GermplasmNewRequest> body) throws BrAPIServerException {
-		List<GermplasmEntity> toSave = new ArrayList<>();
-		for (GermplasmNewRequest germplasm : body) {
-			GermplasmEntity entity = new GermplasmEntity();
-			updateEntity(entity, germplasm);
-			toSave.add(entity);
-		}
 		// Save batch.
-		return germplasmRepository.saveAll(toSave)
+		return germplasmRepository.saveAll(createEntitiesInBatch(body))
 				.stream()
 				.map(this::convertFromEntity)
 				.collect(Collectors.toList());
@@ -570,6 +564,106 @@ public class GermplasmService {
 			germ.setTaxonIds(entity.getTaxonIds().stream().map(this::convertFromEntity).collect(Collectors.toList()));
 
 		return germ;
+	}
+
+	private List<GermplasmEntity> createEntitiesInBatch(List<GermplasmNewRequest> body)
+		throws BrAPIServerException {
+		List<GermplasmEntity> toSave = new ArrayList<>();
+
+		List<String> breedingMethodIds = body.stream()
+				.map(GermplasmNewRequest::getBreedingMethodDbId)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
+		// Use a set since all crop names are likely all or mostly the same.
+		Set<String> cropNames = body.stream()
+				.map(GermplasmNewRequest::getCommonCropName)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toSet());
+
+		Map<String, BreedingMethodEntity> foundBreedingMethodsById
+				= breedingMethodService.findBreedingMethodsByIds(breedingMethodIds)
+				.stream()
+				.collect(Collectors.toMap(BrAPIBaseEntity::getId, e -> e));
+		Map<String, CropEntity> foundCropsByCropName
+				= cropService.findCropsByNames(new ArrayList<>(cropNames))
+				.stream()
+				.collect(Collectors.toMap(CropEntity::getCropName, e -> e));
+
+		for (GermplasmNewRequest request : body) {
+			GermplasmEntity entity = new GermplasmEntity();
+
+			UpdateUtility.updateEntity(request, entity);
+
+			if (request.getAccessionNumber() != null)
+				entity.setAccessionNumber(request.getAccessionNumber());
+			if (request.getAcquisitionDate() != null) {
+				entity.setAcquisitionDate(DateUtility.toDate(request.getAcquisitionDate()));
+				entity.setAcquisitionSourceCode(AcquisitionSourceCodeEnum._99);
+			}
+			if (request.getBiologicalStatusOfAccessionCode() != null)
+				entity.setBiologicalStatusOfAccessionCode(request.getBiologicalStatusOfAccessionCode());
+			if (request.getBreedingMethodDbId() != null) {
+				entity.setBreedingMethod(foundBreedingMethodsById.get(request.getBreedingMethodDbId()));
+			}
+			if (request.getCollection() != null)
+				entity.setCollection(request.getCollection());
+			if (request.getCommonCropName() != null) {
+				CropEntity crop = foundCropsByCropName.get(request.getCommonCropName());
+				if (crop == null) {
+					crop = cropService.saveCropEntity(request.getCommonCropName());
+				}
+				entity.setCrop(crop);
+			}
+			if (request.getCountryOfOriginCode() != null)
+				entity.setCountryOfOriginCode(request.getCountryOfOriginCode());
+			if (request.getDefaultDisplayName() != null)
+				entity.setDefaultDisplayName(request.getDefaultDisplayName());
+			if (request.getDocumentationURL() != null)
+				entity.setDocumentationURL(request.getDocumentationURL());
+			if (request.getDonors() != null)
+				updateDonorEntities(request.getDonors(), entity);
+			if (request.getGenus() != null)
+				entity.setGenus(request.getGenus());
+			if (request.getGermplasmName() != null)
+				entity.setGermplasmName(request.getGermplasmName());
+			if (request.getGermplasmOrigin() != null)
+				updateOriginEntities(request.getGermplasmOrigin(), entity);
+			if (request.getGermplasmPreprocessing() != null)
+				entity.setGermplasmPreprocessing(request.getGermplasmPreprocessing());
+			if (request.getGermplasmPUI() != null)
+				entity.setGermplasmPUI(request.getGermplasmPUI());
+			if (request.getInstituteCode() != null || request.getInstituteName() != null)
+				entity.setHostInstitute(request.getInstituteCode(), request.getInstituteName());
+			entity.setMlsStatus(MlsStatusEnum.EMPTY);
+			if (request.getPedigree() != null) {
+				if(entity.getPedigree() == null) {
+					entity.setPedigree(new PedigreeNodeEntity());
+				}
+				entity.getPedigree().setPedigreeString(request.getPedigree());
+			}
+			if (request.getSeedSource() != null)
+				entity.setSeedSource(request.getSeedSource());
+			if (request.getSeedSourceDescription() != null)
+				entity.setSeedSourceDescription(request.getSeedSourceDescription());
+			if (request.getSpecies() != null)
+				entity.setSpecies(request.getSpecies());
+			if (request.getSpeciesAuthority() != null)
+				entity.setSpeciesAuthority(request.getSpeciesAuthority());
+			if (request.getStorageTypes() != null)
+				entity.setTypeOfGermplasmStorageCode(request.getStorageTypes().stream().filter(Objects::nonNull)
+						.map(GermplasmStorageTypes::getCode).collect(Collectors.toList()));
+			if (request.getSubtaxa() != null)
+				entity.setSubtaxa(request.getSubtaxa());
+			if (request.getSubtaxaAuthority() != null)
+				entity.setSubtaxaAuthority(request.getSubtaxaAuthority());
+			if (request.getSynonyms() != null)
+				updateSynonymEntities(request.getSynonyms(), entity);
+			if (request.getTaxonIds() != null)
+				updateTaxonEntities(request.getTaxonIds(), entity);
+
+			toSave.add(entity);
+		}
+		return toSave;
 	}
 
 	private void updateEntity(GermplasmEntity entity, GermplasmNewRequest request) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -1,20 +1,14 @@
 package org.brapi.test.BrAPITestServer.service.germ;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
-import java.util.Optional;
-import java.util.Set;
 
 import io.swagger.model.IndexPagination;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
+import org.brapi.test.BrAPITestServer.model.entity.BrAPIBaseEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.CrossingProjectEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.GermplasmEntity;
 import org.brapi.test.BrAPITestServer.model.entity.germ.PedigreeEdgeEntity;
@@ -177,22 +171,74 @@ public class PedigreeService {
 		return node;
 	}
 
-	public PedigreeNodeEntity findOrCreatePedigreeNode(String germplasmDbId) throws BrAPIServerException {
-		Optional<PedigreeNodeEntity> nodeOpt = getPedigreeNode(germplasmDbId);
-		PedigreeNodeEntity node;
-		if (nodeOpt.isPresent()) {
-			node = nodeOpt.get();
-		} else {
-			GermplasmEntity germplasm = germplasmService.getGermplasmEntity(germplasmDbId);
+	public List<PedigreeNodeEntity> getPedigreeNodes(List<String> germplasmDbIds) {
+		List<PedigreeNodeEntity> nodes = new ArrayList<>();
+
+		// TODO: Might have to make a custom query for this that fetches the germ eagerly, bc need to compare the germIds.  Have to see if this is a significant performance hit.
+		List<PedigreeNodeEntity> dbNodeList = pedigreeRepository.findByGermplasm_IdIn(germplasmDbIds);
+
+		Map<String, List<PedigreeNodeEntity>> nodesGroupedByGerm = dbNodeList.stream().collect(Collectors.groupingBy(pn -> pn.getGermplasm().getId()));
+
+		nodesGroupedByGerm.forEach((germId, nodesByGerm) -> {
+			if (nodesByGerm.size() > 1) {
+				log.error("multiple pedigree nodes found for a single germplasm");
+			}
+
+			Optional<PedigreeNodeEntity> node = nodesByGerm.stream().findFirst();
+
+			node.ifPresent(nodes::add);
+		});
+
+		return nodes;
+	}
+
+	public List<PedigreeNodeEntity> findOrCreatePedigreeNodesFromGermplasmIds(List<String> germplasmDbIds) throws BrAPIServerException {
+
+        List<PedigreeNodeEntity> dbNodes = getPedigreeNodes(germplasmDbIds);
+
+        List<PedigreeNodeEntity> resultingNodes = new ArrayList<>(dbNodes);
+
+		// Find out which germIds were not found in the DB. Use a set for improved performance on the contains check.
+		// TODO: Check if the germEntity is already populated by getPedigreeNodes, and if this block results in more DB transactions.
+		Set<String> germIdsOfFoundNodes = dbNodes.stream()
+				.map(PedigreeNodeEntity::getGermplasm)
+				.map(BrAPIBaseEntity::getId)
+				.collect(Collectors.toSet());
+
+		List<String> germIdsWithNoPedigreeRecord = germplasmDbIds.stream()
+				.filter(gId -> !germIdsOfFoundNodes.contains(gId))
+				.collect(Collectors.toList());
+
+		// Now see if there are germplasm records that exist from the list created above that have a pedigree associated.
+		// If they do have a pedigree associated, add it to the result list.
+		// If not, create a Pedigree with that Germplasm record.
+		// TODO: Might need this to fetch the pedigree records on this query, otherwise a lazy load occurs
+		List<GermplasmEntity>  germplasms = new ArrayList<>();
+
+		if (!germIdsWithNoPedigreeRecord.isEmpty()) {
+			germplasms = germplasmService.findByIds(germIdsWithNoPedigreeRecord);
+		}
+
+		List<PedigreeNodeEntity> nodesToCreate = new ArrayList<>();
+
+		for (GermplasmEntity germplasm : germplasms) {
+			// This is a lazy load
 			if (germplasm.getPedigree() != null) {
-				node = germplasm.getPedigree();
+				resultingNodes.add(germplasm.getPedigree());
 			} else {
+				// No pedigree exists for this germplasm.  Create one and add the germplasm to it.
 				PedigreeNodeEntity newNode = new PedigreeNodeEntity();
 				newNode.setGermplasm(germplasm);
-				node = pedigreeRepository.save(newNode);
+				nodesToCreate.add(newNode);
 			}
 		}
-		return node;
+
+		// If any new nodes were made, save them and add them to the result list.
+		if (!nodesToCreate.isEmpty()) {
+			resultingNodes.addAll(pedigreeRepository.saveAll(nodesToCreate));
+		}
+
+		return resultingNodes;
 	}
 
 	public PedigreeNode getGermplasmPedigree(String germplasmDbId, Boolean includeSiblings)
@@ -240,7 +286,7 @@ public class PedigreeService {
 
 	public List<PedigreeNode> savePedigreeNodes(List<PedigreeNode> request) throws BrAPIServerException {
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(
-				request.stream().map(p -> p.getGermplasmDbId()).collect(Collectors.toList()));
+				request.stream().map(PedigreeNode::getGermplasmDbId).collect(Collectors.toList()));
 
 		if (!nodesByGermplasm.isEmpty()) {
 			String errorMsg = "The following germplasmDbIds already have existing pedigree data. Please use PUT /pedigree to update these germplasm. \n"
@@ -269,17 +315,24 @@ public class PedigreeService {
 		List<PedigreeNodeEntity> newEntities = new ArrayList<>();
 
 		// TODO: Batch this
+
+		Map<String, Pair<PedigreeNodeEntity, PedigreeNode>> entityDtoPairsByGermplasmId = new HashMap<>();
+
 		for (Entry<String, PedigreeNode> entry : request.entrySet()) {
-			PedigreeNodeEntity entity = nodesByGermplasm.get(entry.getKey());
+			String germId = entry.getKey();
+			PedigreeNodeEntity entity = nodesByGermplasm.get(germId);
+
 			if (entity != null) {
-				updateEntityWithEdges(entity, entry.getValue());
-				newEntities.add(entity);
+				entityDtoPairsByGermplasmId.put(germId, Pair.of(entity, entry.getValue()));
 			} else {
 				throw new BrAPIServerDbIdNotFoundException("germplasm", entry.getKey(), HttpStatus.BAD_REQUEST);
 			}
 		}
 
-		List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAll(newEntities);
+		// First, update the basic properties of the nodes in batch.
+		updateEntitiesWithEdgesInBatch(entityDtoPairsByGermplasmId);
+
+		List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAll(entityDtoPairsByGermplasmId.values().stream().map(Pair::getLeft).collect(Collectors.toList()));
 		List<PedigreeNode> saved = convertFromEntities(savedEntities,
 				new PedigreeSearchRequest().includeParents(true).includeProgeny(true).includeSiblings(true));
 		return saved;
@@ -302,8 +355,13 @@ public class PedigreeService {
 				}
 			}
 
-			savePedigreeNodes(createPedigreeNodes);
-			updatePedigreeNodes(updatePedigreeNodes);
+			if (!createPedigreeNodes.isEmpty()) {
+				savePedigreeNodes(createPedigreeNodes);
+			}
+
+			if (!updatePedigreeNodes.isEmpty()) {
+				updatePedigreeNodes(updatePedigreeNodes);
+			}
 		} else {
 			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(data));
 		}
@@ -536,51 +594,173 @@ public class PedigreeService {
 		return result;
 	}
 
-	private void updateEntityWithEdges(PedigreeNodeEntity entity, PedigreeNode node) throws BrAPIServerException {
-		UpdateUtility.updateEntity(node, entity);
-		updateEntity(entity, node);
-		if (node.getParents() != null) {
+	// This method should be used in use cases where there are existing node entities that may have edges.
+	private void updateEntitiesWithEdgesInBatch(Map<String, Pair<PedigreeNodeEntity,
+			PedigreeNode>> entityDtoPairsByGermId) throws BrAPIServerException {
+		List<String> germIds = new ArrayList<>(entityDtoPairsByGermId.keySet());
+		List<String> crossingProjIds = entityDtoPairsByGermId.values()
+				.stream()
+				.map(nodePair -> nodePair.getRight().getCrossingProjectDbId())
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
 
-			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
-			search.appendSingle(node.getGermplasmDbId(), "connectedNode.germplasm.id");
+		List<String> germIdsWithParentNodes = entityDtoPairsByGermId.entrySet()
+				.stream()
+				.filter(entry -> entry.getValue().getRight().getParents() != null)
+				.map(Entry::getKey)
+				.collect(Collectors.toList());
+
+		List<String> germIdsWithProgenyNodes = entityDtoPairsByGermId.entrySet()
+				.stream()
+				.filter(entry -> entry.getValue().getRight().getProgeny() != null)
+				.map(Entry::getKey)
+				.collect(Collectors.toList());
+
+		List<GermplasmEntity> germs = new ArrayList<>();
+		List<CrossingProjectEntity> crossingProjs = new ArrayList<>();
+
+		if (!germIds.isEmpty()) {
+			germs = germplasmService.findByIds(germIds);
+		}
+		if (!crossingProjIds.isEmpty()) {
+			crossingProjs = crossingProjectService.findCrossingProjectsByIds(crossingProjIds);
+		}
+
+		if (!germIdsWithParentNodes.isEmpty()) {
+			List<String> parentEdgesToDelete = new ArrayList<>();
+
+			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<>(PedigreeEdgeEntity.class);
+			search.appendList(germIdsWithParentNodes, "connectedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
+			// TODO: Does not need to be a paginated search.
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
 			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
 
-			List<String> edgeIdsToDelete = new ArrayList<>();
-			edgeIdsToDelete.addAll(entity.getParentEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
-			edgeIdsToDelete.addAll(existingParentEdges.getContent().stream().map(e -> e.getId()).collect(Collectors.toList()));
+			List<String> existingParentEdgesFromPassedEntities = entityDtoPairsByGermId.entrySet()
+					.stream()
+					.flatMap(entry -> entry.getValue().getLeft().getParentEdges().stream())
+					.map(BrAPIBaseEntity::getId)
+					.collect(Collectors.toList());
 
-			if (!edgeIdsToDelete.isEmpty()) {
-				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
+			parentEdgesToDelete.addAll(existingParentEdgesFromPassedEntities);
+			parentEdgesToDelete.addAll(existingParentEdges.getContent().stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
+
+			if (!parentEdgesToDelete.isEmpty()) {
+				pedigreeEdgeRepository.deleteAllByIdInBatch(parentEdgesToDelete);
 			}
 
-			for (PedigreeNodeParents parentNode : node.getParents()) {
-				PedigreeNodeEntity parentEntity = findOrCreatePedigreeNode(parentNode.getGermplasmDbId());
-				entity.addParent(parentEntity, parentNode.getParentType());
-				parentEntity.addProgeny(entity, parentNode.getParentType());
+			List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithParents = entityDtoPairsByGermId.values()
+					.stream()
+					.filter(p -> !p.getRight().getParents().isEmpty())
+					.collect(Collectors.toList());
+
+			List<String> germIdsOfAllParents = nodesWithParents.stream()
+					.flatMap(p -> p.getRight().getParents().stream())
+					.map(PedigreeNodeParents::getGermplasmDbId)
+					.collect(Collectors.toList());
+
+
+			List<PedigreeNodeEntity> createdOrFoundParentNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllParents);
+
+			for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithParent : nodesWithParents) {
+				PedigreeNodeEntity nodeEntity = nodeWithParent.getLeft();
+				PedigreeNode nodeDto = nodeWithParent.getRight();
+				for (PedigreeNodeParents parentNode : nodeDto.getParents()) {
+					// Is it possible that more that any of these parents share the same germplasm ID?  If so, we need to figure out how to handle that use case.
+					PedigreeNodeEntity parentEntity = createdOrFoundParentNodes.stream()
+							.filter(pne -> pne.getGermplasm().getId().equals(parentNode.getGermplasmDbId()))
+							.findFirst()
+							.orElse(null);
+
+					// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
+					// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
+					if (parentEntity != null) {
+						nodeEntity.addParent(parentEntity, parentNode.getParentType());
+						parentEntity.addProgeny(nodeEntity, parentNode.getParentType());
+					}
+				}
 			}
 		}
-		if (node.getProgeny() != null) {
+
+		if (!germIdsWithProgenyNodes.isEmpty()) {
+			List<String> progenyEdgesToDelete = new ArrayList<>();
 
 			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
-			search.appendSingle(node.getGermplasmDbId(), "connectedNode.germplasm.id");
+
+			search.appendList(germIdsWithProgenyNodes, "conncetedNode.germplasm.id");
 			search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
 			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
 			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
 
-			List<String> edgeIdsToDelete = new ArrayList<>();
-			edgeIdsToDelete.addAll(entity.getProgenyEdges().stream().map(e -> e.getId()).collect(Collectors.toList()));
-			edgeIdsToDelete.addAll(existingProgenyEdges.getContent().stream().map(e -> e.getId()).collect(Collectors.toList()));
+			List<String> existingProgenyEdgeFromPassedEntities = entityDtoPairsByGermId.entrySet()
+					.stream()
+					.flatMap(entry -> entry.getValue().getLeft().getProgenyEdges().stream())
+					.map(BrAPIBaseEntity::getId)
+					.collect(Collectors.toList());
 
-			if (!edgeIdsToDelete.isEmpty()) {
-				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
+			progenyEdgesToDelete.addAll(existingProgenyEdgeFromPassedEntities);
+			progenyEdgesToDelete.addAll(existingProgenyEdges.getContent().stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
+
+			if (!progenyEdgesToDelete.isEmpty()) {
+				pedigreeEdgeRepository.deleteAllByIdInBatch(progenyEdgesToDelete);
 			}
 
-			for (PedigreeNodeParents childNode : node.getProgeny()) {
-				PedigreeNodeEntity childEntity = findOrCreatePedigreeNode(childNode.getGermplasmDbId());
-				entity.addProgeny(childEntity, childNode.getParentType());
-				childEntity.addParent(entity, childNode.getParentType());
+			List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithProgeny = entityDtoPairsByGermId.values()
+					.stream()
+					.filter(p -> !p.getRight().getProgeny().isEmpty())
+					.collect(Collectors.toList());
+
+			List<String> germIdsOfAllProgeny = nodesWithProgeny.stream()
+					.flatMap(p -> p.getRight().getParents().stream())
+					.map(PedigreeNodeParents::getGermplasmDbId)
+					.collect(Collectors.toList());
+
+			List<PedigreeNodeEntity> createdOrFoundProgenyNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllProgeny);
+
+			for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithProgeny : nodesWithProgeny) {
+				PedigreeNodeEntity nodeEntity = nodeWithProgeny.getLeft();
+				PedigreeNode nodeDto = nodeWithProgeny.getRight();
+				// Create a map of Nodes with progeny to its
+
+				for (PedigreeNodeParents childNode : nodeDto.getProgeny()) {
+					PedigreeNodeEntity childEntity = createdOrFoundProgenyNodes.stream()
+							.filter(pne -> pne.getGermplasm().getId().equals(childNode.getGermplasmDbId()))
+							.findFirst()
+							.orElse(null);
+
+					// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
+					// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
+					if (childEntity != null) {
+						nodeEntity.addParent(childEntity, childNode.getParentType());
+						childEntity.addProgeny(nodeEntity, childNode.getParentType());
+					}
+				}
+			}
+		}
+
+		for (Entry<String, Pair<PedigreeNodeEntity, PedigreeNode>>  entityDtoPairByGermId: entityDtoPairsByGermId.entrySet()) {
+			PedigreeNodeEntity entity = entityDtoPairByGermId.getValue().getLeft();
+			PedigreeNode node = entityDtoPairByGermId.getValue().getRight();
+
+			if (node.getGermplasmDbId() != null && entity.getGermplasm() == null) {
+				String germId = node.getGermplasmDbId();
+				Optional<GermplasmEntity> germEntity = germs.stream().filter(ge -> ge.getId().equals(germId)).findFirst();
+				germEntity.ifPresent(entity::setGermplasm);
+			}
+
+			UpdateUtility.updateEntity(node, entity);
+
+			if (node.getCrossingYear() != null)
+				entity.setCrossingYear(node.getCrossingYear());
+			if (node.getFamilyCode() != null)
+				entity.setFamilyCode(node.getFamilyCode());
+			if (node.getPedigreeString() != null)
+				entity.setPedigreeString(node.getPedigreeString());
+
+			if (node.getCrossingProjectDbId() != null) {
+				String cpId = node.getCrossingProjectDbId();
+				Optional<CrossingProjectEntity> crossingProjectEntity = crossingProjs.stream().filter(cp -> cp.getId().equals(cpId)).findFirst();
+				crossingProjectEntity.ifPresent(entity::setCrossingProject);
 			}
 		}
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -595,8 +595,8 @@ public class PedigreeService {
 	}
 
 	// This method should be used in use cases where there are existing node entities that may have edges.
-	private void updateEntitiesWithEdgesInBatch(Map<String, Pair<PedigreeNodeEntity,
-			PedigreeNode>> entityDtoPairsByGermId) throws BrAPIServerException {
+	private void updateEntitiesWithEdgesInBatch(Map<String, Pair<PedigreeNodeEntity, PedigreeNode>> entityDtoPairsByGermId)
+			throws BrAPIServerException {
 		List<String> germIds = new ArrayList<>(entityDtoPairsByGermId.keySet());
 		List<String> crossingProjIds = entityDtoPairsByGermId.values()
 				.stream()
@@ -627,115 +627,11 @@ public class PedigreeService {
 		}
 
 		if (!germIdsWithParentNodes.isEmpty()) {
-			List<String> parentEdgesToDelete = new ArrayList<>();
-
-			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<>(PedigreeEdgeEntity.class);
-			search.appendList(germIdsWithParentNodes, "connectedNode.germplasm.id");
-			search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
-			// TODO: Does not need to be a paginated search.
-			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
-			Page<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
-
-			List<String> existingParentEdgesFromPassedEntities = entityDtoPairsByGermId.entrySet()
-					.stream()
-					.flatMap(entry -> entry.getValue().getLeft().getParentEdges().stream())
-					.map(BrAPIBaseEntity::getId)
-					.collect(Collectors.toList());
-
-			parentEdgesToDelete.addAll(existingParentEdgesFromPassedEntities);
-			parentEdgesToDelete.addAll(existingParentEdges.getContent().stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
-
-			if (!parentEdgesToDelete.isEmpty()) {
-				pedigreeEdgeRepository.deleteAllByIdInBatch(parentEdgesToDelete);
-			}
-
-			List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithParents = entityDtoPairsByGermId.values()
-					.stream()
-					.filter(p -> !p.getRight().getParents().isEmpty())
-					.collect(Collectors.toList());
-
-			List<String> germIdsOfAllParents = nodesWithParents.stream()
-					.flatMap(p -> p.getRight().getParents().stream())
-					.map(PedigreeNodeParents::getGermplasmDbId)
-					.collect(Collectors.toList());
-
-
-			List<PedigreeNodeEntity> createdOrFoundParentNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllParents);
-
-			for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithParent : nodesWithParents) {
-				PedigreeNodeEntity nodeEntity = nodeWithParent.getLeft();
-				PedigreeNode nodeDto = nodeWithParent.getRight();
-				for (PedigreeNodeParents parentNode : nodeDto.getParents()) {
-					// Is it possible that more that any of these parents share the same germplasm ID?  If so, we need to figure out how to handle that use case.
-					PedigreeNodeEntity parentEntity = createdOrFoundParentNodes.stream()
-							.filter(pne -> pne.getGermplasm().getId().equals(parentNode.getGermplasmDbId()))
-							.findFirst()
-							.orElse(null);
-
-					// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
-					// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
-					if (parentEntity != null) {
-						nodeEntity.addParent(parentEntity, parentNode.getParentType());
-						parentEntity.addProgeny(nodeEntity, parentNode.getParentType());
-					}
-				}
-			}
+			updateParentEdges(germIdsWithParentNodes, entityDtoPairsByGermId);
 		}
 
 		if (!germIdsWithProgenyNodes.isEmpty()) {
-			List<String> progenyEdgesToDelete = new ArrayList<>();
-
-			SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
-
-			search.appendList(germIdsWithProgenyNodes, "conncetedNode.germplasm.id");
-			search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
-			Pageable defaultPageSize = PagingUtility.getPageRequest(new Metadata().pagination(new IndexPagination().pageSize(10000000)));
-			Page<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearchAndPaginate(search, defaultPageSize);
-
-			List<String> existingProgenyEdgeFromPassedEntities = entityDtoPairsByGermId.entrySet()
-					.stream()
-					.flatMap(entry -> entry.getValue().getLeft().getProgenyEdges().stream())
-					.map(BrAPIBaseEntity::getId)
-					.collect(Collectors.toList());
-
-			progenyEdgesToDelete.addAll(existingProgenyEdgeFromPassedEntities);
-			progenyEdgesToDelete.addAll(existingProgenyEdges.getContent().stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
-
-			if (!progenyEdgesToDelete.isEmpty()) {
-				pedigreeEdgeRepository.deleteAllByIdInBatch(progenyEdgesToDelete);
-			}
-
-			List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithProgeny = entityDtoPairsByGermId.values()
-					.stream()
-					.filter(p -> !p.getRight().getProgeny().isEmpty())
-					.collect(Collectors.toList());
-
-			List<String> germIdsOfAllProgeny = nodesWithProgeny.stream()
-					.flatMap(p -> p.getRight().getParents().stream())
-					.map(PedigreeNodeParents::getGermplasmDbId)
-					.collect(Collectors.toList());
-
-			List<PedigreeNodeEntity> createdOrFoundProgenyNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllProgeny);
-
-			for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithProgeny : nodesWithProgeny) {
-				PedigreeNodeEntity nodeEntity = nodeWithProgeny.getLeft();
-				PedigreeNode nodeDto = nodeWithProgeny.getRight();
-				// Create a map of Nodes with progeny to its
-
-				for (PedigreeNodeParents childNode : nodeDto.getProgeny()) {
-					PedigreeNodeEntity childEntity = createdOrFoundProgenyNodes.stream()
-							.filter(pne -> pne.getGermplasm().getId().equals(childNode.getGermplasmDbId()))
-							.findFirst()
-							.orElse(null);
-
-					// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
-					// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
-					if (childEntity != null) {
-						nodeEntity.addParent(childEntity, childNode.getParentType());
-						childEntity.addProgeny(nodeEntity, childNode.getParentType());
-					}
-				}
-			}
+			updateChildEdges(germIdsWithProgenyNodes, entityDtoPairsByGermId);
 		}
 
 		for (Entry<String, Pair<PedigreeNodeEntity, PedigreeNode>>  entityDtoPairByGermId: entityDtoPairsByGermId.entrySet()) {
@@ -761,6 +657,120 @@ public class PedigreeService {
 				String cpId = node.getCrossingProjectDbId();
 				Optional<CrossingProjectEntity> crossingProjectEntity = crossingProjs.stream().filter(cp -> cp.getId().equals(cpId)).findFirst();
 				crossingProjectEntity.ifPresent(entity::setCrossingProject);
+			}
+		}
+	}
+
+	private void updateParentEdges(List<String> germIdsWithParentNodes,
+								   Map<String, Pair<PedigreeNodeEntity, PedigreeNode>> entityDtoPairsByGermId)
+		throws BrAPIServerException {
+
+		List<String> parentEdgesToDelete = new ArrayList<>();
+
+		SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<>(PedigreeEdgeEntity.class);
+		search.appendList(germIdsWithParentNodes, "connectedNode.germplasm.id");
+		search.appendEnum(PedigreeEdgeEntity.EdgeType.child, "edgeType");
+		List<PedigreeEdgeEntity> existingParentEdges = pedigreeEdgeRepository.findAllBySearch(search);
+
+		List<String> existingParentEdgesFromPassedEntities = entityDtoPairsByGermId.entrySet()
+				.stream()
+				.flatMap(entry -> entry.getValue().getLeft().getParentEdges().stream())
+				.map(BrAPIBaseEntity::getId)
+				.collect(Collectors.toList());
+
+		parentEdgesToDelete.addAll(existingParentEdgesFromPassedEntities);
+		parentEdgesToDelete.addAll(existingParentEdges.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
+
+		if (!parentEdgesToDelete.isEmpty()) {
+			pedigreeEdgeRepository.deleteAllByIdInBatch(parentEdgesToDelete);
+		}
+
+		List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithParents = entityDtoPairsByGermId.values()
+				.stream()
+				.filter(p -> !p.getRight().getParents().isEmpty())
+				.collect(Collectors.toList());
+
+		List<String> germIdsOfAllParents = nodesWithParents.stream()
+				.flatMap(p -> p.getRight().getParents().stream())
+				.map(PedigreeNodeParents::getGermplasmDbId)
+				.collect(Collectors.toList());
+
+
+		List<PedigreeNodeEntity> createdOrFoundParentNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllParents);
+
+		for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithParent : nodesWithParents) {
+			PedigreeNodeEntity nodeEntity = nodeWithParent.getLeft();
+			PedigreeNode nodeDto = nodeWithParent.getRight();
+			for (PedigreeNodeParents parentNode : nodeDto.getParents()) {
+				// Is it possible that more that any of these parents share the same germplasm ID?  If so, we need to figure out how to handle that use case.
+				PedigreeNodeEntity parentEntity = createdOrFoundParentNodes.stream()
+						.filter(pne -> pne.getGermplasm().getId().equals(parentNode.getGermplasmDbId()))
+						.findFirst()
+						.orElse(null);
+
+				// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
+				// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
+				if (parentEntity != null) {
+					nodeEntity.addParent(parentEntity, parentNode.getParentType());
+					parentEntity.addProgeny(nodeEntity, parentNode.getParentType());
+				}
+			}
+		}
+	}
+
+	private void updateChildEdges(List<String> germIdsWithProgenyNodes,
+								  Map<String, Pair<PedigreeNodeEntity, PedigreeNode>> entityDtoPairsByGermId)
+		throws BrAPIServerException {
+		List<String> progenyEdgesToDelete = new ArrayList<>();
+
+		SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
+
+		search.appendList(germIdsWithProgenyNodes, "conncetedNode.germplasm.id");
+		search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
+		List<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search);
+
+		List<String> existingProgenyEdgeFromPassedEntities = entityDtoPairsByGermId.entrySet()
+				.stream()
+				.flatMap(entry -> entry.getValue().getLeft().getProgenyEdges().stream())
+				.map(BrAPIBaseEntity::getId)
+				.collect(Collectors.toList());
+
+		progenyEdgesToDelete.addAll(existingProgenyEdgeFromPassedEntities);
+		progenyEdgesToDelete.addAll(existingProgenyEdges.stream().map(BrAPIBaseEntity::getId).collect(Collectors.toList()));
+
+		if (!progenyEdgesToDelete.isEmpty()) {
+			pedigreeEdgeRepository.deleteAllByIdInBatch(progenyEdgesToDelete);
+		}
+
+		List<Pair<PedigreeNodeEntity, PedigreeNode>> nodesWithProgeny = entityDtoPairsByGermId.values()
+				.stream()
+				.filter(p -> !p.getRight().getProgeny().isEmpty())
+				.collect(Collectors.toList());
+
+		List<String> germIdsOfAllProgeny = nodesWithProgeny.stream()
+				.flatMap(p -> p.getRight().getParents().stream())
+				.map(PedigreeNodeParents::getGermplasmDbId)
+				.collect(Collectors.toList());
+
+		List<PedigreeNodeEntity> createdOrFoundProgenyNodes = findOrCreatePedigreeNodesFromGermplasmIds(germIdsOfAllProgeny);
+
+		for (Pair<PedigreeNodeEntity, PedigreeNode> nodeWithProgeny : nodesWithProgeny) {
+			PedigreeNodeEntity nodeEntity = nodeWithProgeny.getLeft();
+			PedigreeNode nodeDto = nodeWithProgeny.getRight();
+			// Create a map of Nodes with progeny to its
+
+			for (PedigreeNodeParents childNode : nodeDto.getProgeny()) {
+				PedigreeNodeEntity childEntity = createdOrFoundProgenyNodes.stream()
+						.filter(pne -> pne.getGermplasm().getId().equals(childNode.getGermplasmDbId()))
+						.findFirst()
+						.orElse(null);
+
+				// Impossible to be null because of exception thrown in findOrCreatePedigreeNodesFromGermplasmIds().
+				// As long as the germIds of all the parents nodes in the rq were supplied, they will be found or created or this code is never executed.
+				if (childEntity != null) {
+					nodeEntity.addParent(childEntity, childNode.getParentType());
+					childEntity.addProgeny(nodeEntity, childNode.getParentType());
+				}
 			}
 		}
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -195,13 +195,12 @@ public class PedigreeService {
 
 	public List<PedigreeNodeEntity> findOrCreatePedigreeNodesFromGermplasmIds(List<String> germplasmDbIds) throws BrAPIServerException {
 
-        List<PedigreeNodeEntity> dbNodes = getPedigreeNodes(germplasmDbIds);
+		// First, grab nodes from the DB that match the germplasmDbIds passed through.
+        List<PedigreeNodeEntity> resultingNodes = getPedigreeNodes(germplasmDbIds);
 
-        List<PedigreeNodeEntity> resultingNodes = new ArrayList<>(dbNodes);
-
-		// Find out which germIds were not found in the DB. Use a set for improved performance on the contains check.
+		// Next, find out which germIds were not found in the DB. Use a set for improved performance on the contains check.
 		// TODO: Check if the germEntity is already populated by getPedigreeNodes, and if this block results in more DB transactions.
-		Set<String> germIdsOfFoundNodes = dbNodes.stream()
+		Set<String> germIdsOfFoundNodes = resultingNodes.stream()
 				.map(PedigreeNodeEntity::getGermplasm)
 				.map(BrAPIBaseEntity::getId)
 				.collect(Collectors.toSet());
@@ -758,7 +757,7 @@ public class PedigreeService {
 
 		SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
 
-		search.appendList(germIdsWithProgenyNodes, "conncetedNode.germplasm.id");
+		search.appendList(germIdsWithProgenyNodes, "connected.germplasm.id");
 		search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
 		List<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search);
 

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.swagger.model.IndexPagination;
+import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
 import org.brapi.test.BrAPITestServer.model.entity.germ.CrossingProjectEntity;
@@ -247,13 +248,8 @@ public class PedigreeService {
 			throw new BrAPIServerException(HttpStatus.BAD_REQUEST, errorMsg);
 		}
 
-		List<PedigreeNodeEntity> newEntities = new ArrayList<>();
-
-		for (PedigreeNode node : request) {
-			PedigreeNodeEntity entity = new PedigreeNodeEntity();
-			updateEntity(entity, node);
-			newEntities.add(entity);
-		}
+		// TODO: Batch this
+		List<PedigreeNodeEntity> newEntities = createEntitiesInBatch(request);
 		// save all the new nodes without edges
 		//TODO: Fix to save nodes and edges at same time
 		pedigreeRepository.saveAll(newEntities);
@@ -272,6 +268,7 @@ public class PedigreeService {
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(new ArrayList<>(request.keySet()));
 		List<PedigreeNodeEntity> newEntities = new ArrayList<>();
 
+		// TODO: Batch this
 		for (Entry<String, PedigreeNode> entry : request.entrySet()) {
 			PedigreeNodeEntity entity = nodesByGermplasm.get(entry.getKey());
 			if (entity != null) {
@@ -329,6 +326,7 @@ public class PedigreeService {
 			List<PedigreeNodeEntity> nodeEntities = findPedigreeEntities(searchReq, null);
 
 			for (PedigreeNodeEntity nodeEntity : nodeEntities) {
+				// TODO: nodeEntity.getGermplasm() causes a lazy load
 				if (nodeEntity.getGermplasm() != null && nodeEntity.getGermplasm().getId() != null) {
 					nodesByGermplasm.put(nodeEntity.getGermplasm().getId(), nodeEntity);
 				}
@@ -494,6 +492,48 @@ public class PedigreeService {
 					.getCrossingProjectEntity(node.getCrossingProjectDbId());
 			entity.setCrossingProject(crossingProject);
 		}
+	}
+
+
+
+	// This method should be used in use cases where there are no existing node entities representing the list being passed through.
+	private List<PedigreeNodeEntity> createEntitiesInBatch(List<PedigreeNode> nodes)
+		throws BrAPIServerException {
+		List<String> germIds = nodes.stream().map(PedigreeNode::getGermplasmDbId).collect(Collectors.toList());
+		List<String> crossingProjIds = nodes.stream().map(PedigreeNode::getCrossingProjectDbId).collect(Collectors.toList());
+
+		List<GermplasmEntity> germs = germplasmService.findByIds(germIds);
+		List<CrossingProjectEntity> crossingProjs = crossingProjectService.findCrossingProjectsByIds(crossingProjIds);
+
+		List<PedigreeNodeEntity> result = new ArrayList<PedigreeNodeEntity>();
+		for (PedigreeNode node : nodes) {
+			PedigreeNodeEntity entity = new PedigreeNodeEntity();
+
+			if (node.getGermplasmDbId() != null) {
+				String germId = node.getGermplasmDbId();
+				Optional<GermplasmEntity> germEntity = germs.stream().filter(ge -> ge.getId().equals(germId)).findFirst();
+				germEntity.ifPresent(entity::setGermplasm);
+			}
+
+			UpdateUtility.updateEntity(node, entity);
+
+			if (node.getCrossingYear() != null)
+				entity.setCrossingYear(node.getCrossingYear());
+			if (node.getFamilyCode() != null)
+				entity.setFamilyCode(node.getFamilyCode());
+			if (node.getPedigreeString() != null)
+				entity.setPedigreeString(node.getPedigreeString());
+
+			if (node.getCrossingProjectDbId() != null) {
+				String cpId = node.getCrossingProjectDbId();
+				Optional<CrossingProjectEntity> crossingProjectEntity = crossingProjs.stream().filter(cp -> cp.getId().equals(cpId)).findFirst();
+                crossingProjectEntity.ifPresent(entity::setCrossingProject);
+			}
+
+			result.add(entity);
+		}
+
+		return result;
 	}
 
 	private void updateEntityWithEdges(PedigreeNodeEntity entity, PedigreeNode node) throws BrAPIServerException {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -284,13 +284,19 @@ public class PedigreeService {
 		return result;
 	}
 
-	public List<PedigreeNode> savePedigreeNodes(List<PedigreeNode> request) throws BrAPIServerException {
+	public List<PedigreeNode> savePedigreeNodes(List<PedigreeNode> request)
+		throws BrAPIServerException {
+		return savePedigreeNodes(request, true);
+	}
+
+	public List<PedigreeNode> savePedigreeNodes(List<PedigreeNode> request,
+												boolean returnValues) throws BrAPIServerException {
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(
 				request.stream().map(PedigreeNode::getGermplasmDbId).collect(Collectors.toList()));
 
 		if (!nodesByGermplasm.isEmpty()) {
 			String errorMsg = "The following germplasmDbIds already have existing pedigree data. Please use PUT /pedigree to update these germplasm. \n"
-					+ nodesByGermplasm.keySet().toString();
+					+ nodesByGermplasm.keySet();
 			throw new BrAPIServerException(HttpStatus.BAD_REQUEST, errorMsg);
 		}
 
@@ -305,16 +311,22 @@ public class PedigreeService {
 			updateRequest.put(newNode.getGermplasmDbId(), newNode);
 		}
 		// update the new nodes with requested edges
-		List<PedigreeNode> saved = updatePedigreeNodes(updateRequest);
-
-		return saved;
+		if (returnValues) {
+			return updatePedigreeNodes(updateRequest);
+		} else {
+			updatePedigreeNodes(updateRequest, false);
+			return Collections.emptyList();
+		}
 	}
 
-	public List<PedigreeNode> updatePedigreeNodes(Map<String, PedigreeNode> request) throws BrAPIServerException {
-		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(new ArrayList<>(request.keySet()));
-		List<PedigreeNodeEntity> newEntities = new ArrayList<>();
+	public List<PedigreeNode> updatePedigreeNodes(Map<String, PedigreeNode> request)
+		throws BrAPIServerException {
+		return updatePedigreeNodes(request, true);
+	}
 
-		// TODO: Batch this
+	public List<PedigreeNode> updatePedigreeNodes(Map<String, PedigreeNode> request,
+												  boolean returnValues) throws BrAPIServerException {
+		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(new ArrayList<>(request.keySet()));
 
 		Map<String, Pair<PedigreeNodeEntity, PedigreeNode>> entityDtoPairsByGermplasmId = new HashMap<>();
 
@@ -332,10 +344,16 @@ public class PedigreeService {
 		// First, update the basic properties of the nodes in batch.
 		updateEntitiesWithEdgesInBatch(entityDtoPairsByGermplasmId);
 
-		List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAll(entityDtoPairsByGermplasmId.values().stream().map(Pair::getLeft).collect(Collectors.toList()));
-		List<PedigreeNode> saved = convertFromEntities(savedEntities,
-				new PedigreeSearchRequest().includeParents(true).includeProgeny(true).includeSiblings(true));
-		return saved;
+		if (returnValues) {
+			List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAll(entityDtoPairsByGermplasmId.values().stream().map(Pair::getLeft).collect(Collectors.toList()));
+			List<PedigreeNode> saved = convertFromEntities(savedEntities,
+					new PedigreeSearchRequest().includeParents(true).includeProgeny(true).includeSiblings(true));
+			return saved;
+		} else {
+			// If no values are required, simply return an empty list.
+			pedigreeRepository.saveAll(entityDtoPairsByGermplasmId.values().stream().map(Pair::getLeft).collect(Collectors.toList()));
+			return Collections.emptyList();
+		}
 	}
 
 	public void updateGermplasmPedigree(List<Germplasm> data) throws BrAPIServerException {
@@ -356,14 +374,14 @@ public class PedigreeService {
 			}
 
 			if (!createPedigreeNodes.isEmpty()) {
-				savePedigreeNodes(createPedigreeNodes);
+				savePedigreeNodes(createPedigreeNodes, false);
 			}
 
 			if (!updatePedigreeNodes.isEmpty()) {
-				updatePedigreeNodes(updatePedigreeNodes);
+				updatePedigreeNodes(updatePedigreeNodes, false);
 			}
 		} else {
-			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(data));
+			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(data), false);
 		}
 
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -188,7 +188,7 @@ public class PedigreeService {
 			} else {
 				PedigreeNodeEntity newNode = new PedigreeNodeEntity();
 				newNode.setGermplasm(germplasm);
-				node = pedigreeRepository.saveAndFlush(newNode);
+				node = pedigreeRepository.save(newNode);
 			}
 		}
 		return node;
@@ -255,7 +255,8 @@ public class PedigreeService {
 			newEntities.add(entity);
 		}
 		// save all the new nodes without edges
-		pedigreeRepository.saveAllAndFlush(newEntities);
+		//TODO: Fix to save nodes and edges at same time
+		pedigreeRepository.saveAll(newEntities);
 
 		Map<String, PedigreeNode> updateRequest = new HashMap<>();
 		for (PedigreeNode newNode : request) {
@@ -281,7 +282,7 @@ public class PedigreeService {
 			}
 		}
 
-		List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAllAndFlush(newEntities);
+		List<PedigreeNodeEntity> savedEntities = pedigreeRepository.saveAll(newEntities);
 		List<PedigreeNode> saved = convertFromEntities(savedEntities,
 				new PedigreeSearchRequest().includeParents(true).includeProgeny(true).includeSiblings(true));
 		return saved;
@@ -291,19 +292,24 @@ public class PedigreeService {
 		List<PedigreeNode> createPedigreeNodes = new ArrayList<>();
 		Map<String, PedigreeNode> updatePedigreeNodes = new HashMap<>();
 
+		// TODO: This always returns empty for the germplasm post path, since this method is always passed a newly created germplasm record.
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(
 				data.stream().map(p -> p.getGermplasmDbId()).collect(Collectors.toList()));
 
-		for (Germplasm germplasm : data) {
-			if (nodesByGermplasm.containsKey(germplasm.getGermplasmDbId())) {
-				updatePedigreeNodes.put(germplasm.getGermplasmDbId(), convertFromGermplasmToPedigree(germplasm));
-			} else {
-				createPedigreeNodes.add(convertFromGermplasmToPedigree(germplasm));
+		if (data.stream().noneMatch(g -> g.getPedigree() != null) || !nodesByGermplasm.isEmpty()) {
+			for (Germplasm germplasm : data) {
+				if (nodesByGermplasm.containsKey(germplasm.getGermplasmDbId())) {
+					updatePedigreeNodes.put(germplasm.getGermplasmDbId(), convertFromGermplasmToPedigree(germplasm));
+				} else {
+					createPedigreeNodes.add(convertFromGermplasmToPedigree(germplasm));
+				}
 			}
-		}
 
-		savePedigreeNodes(createPedigreeNodes);
-		updatePedigreeNodes(updatePedigreeNodes);
+			savePedigreeNodes(createPedigreeNodes);
+			updatePedigreeNodes(updatePedigreeNodes);
+		} else {
+			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(data));
+		}
 
 	}
 
@@ -507,7 +513,6 @@ public class PedigreeService {
 
 			if (!edgeIdsToDelete.isEmpty()) {
 				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
-				pedigreeEdgeRepository.flush();
 			}
 
 			for (PedigreeNodeParents parentNode : node.getParents()) {
@@ -530,7 +535,6 @@ public class PedigreeService {
 
 			if (!edgeIdsToDelete.isEmpty()) {
 				pedigreeEdgeRepository.deleteAllByIdInBatch(edgeIdsToDelete);
-				pedigreeEdgeRepository.flush();
 			}
 
 			for (PedigreeNodeParents childNode : node.getProgeny()) {
@@ -541,6 +545,48 @@ public class PedigreeService {
 		}
 	}
 
+	public List<PedigreeNode> convertFromGermplasmToPedigreeBatchUsingNames(List<Germplasm> germplasms)
+		throws BrAPIServerException{
+		List<PedigreeNode> result = new ArrayList<PedigreeNode>();
+
+		Map<Germplasm, String> germsByPedigreeMother = new HashMap<>();
+		Map<Germplasm, String> germsByPedigreeFather = new HashMap<>();
+
+		for (Germplasm germplasm : germplasms) {
+			List<String> pedigreeList = Arrays.asList(germplasm.getPedigree().split("/"));
+
+			if (!pedigreeList.isEmpty()) {
+				germsByPedigreeMother.put(germplasm, pedigreeList.get(0));
+
+				if (pedigreeList.size() > 1) {
+					germsByPedigreeFather.put(germplasm, pedigreeList.get(1));
+				}
+			}
+		}
+
+		List<GermplasmEntity> motherGerms = germplasmService.findByNames(new ArrayList<>(germsByPedigreeMother.values()));
+		List<GermplasmEntity> fatherGerms = germplasmService.findByNames(new ArrayList<>(germsByPedigreeFather.values()));
+
+		for (Germplasm germplasm : germplasms) {
+			GermplasmEntity motherGerm = null;
+			GermplasmEntity fatherGerm = null;
+
+			if (germsByPedigreeMother.containsKey(germplasm)) {
+				String motherString = germsByPedigreeMother.get(germplasm);
+				motherGerm = motherGerms.stream().filter(g -> g.getGermplasmName().equals(motherString)).findFirst().orElse(null);
+			}
+
+			if (germsByPedigreeFather.containsKey(germplasm)) {
+				String fatherString = germsByPedigreeFather.get(germplasm);
+				fatherGerm = fatherGerms.stream().filter(g -> g.getGermplasmName().equals(fatherString)).findFirst().orElse(null);
+			}
+
+			result.add(createPedigreeFromGermplasm(germplasm, motherGerm, fatherGerm));
+		}
+
+		return result;
+	}
+
 	public PedigreeNode convertFromGermplasmToPedigree(Germplasm germplasm)
 		throws BrAPIServerException {
 		PedigreeNode node = new PedigreeNode();
@@ -549,14 +595,26 @@ public class PedigreeService {
 		if (germplasm.getPedigree() != null) {
 			pedigreeList = Arrays.asList(germplasm.getPedigree().split("/"));
 		}
-		Optional<GermplasmEntity> motherOpt = Optional.empty();
-		Optional<GermplasmEntity> fatherOpt = Optional.empty();
+
+		// TODO: Could split this up into one query in batch that returns a Map of Germplasm to its Nodes.
+		GermplasmEntity motherGerm = null;
+		GermplasmEntity fatherGerm = null;
 		if (pedigreeList.size() > 0) {
-			motherOpt = Optional.ofNullable(germplasmService.findByUnknownIdentity(pedigreeList.get(0)));
+			motherGerm = germplasmService.findByUnknownIdentity(pedigreeList.get(0));
 			if (pedigreeList.size() > 1) {
-				fatherOpt = Optional.ofNullable(germplasmService.findByUnknownIdentity(pedigreeList.get(1)));
+				fatherGerm = germplasmService.findByUnknownIdentity(pedigreeList.get(1));
 			}
 		}
+
+		return createPedigreeFromGermplasm(germplasm,
+				motherGerm,
+				fatherGerm);
+	}
+
+	public PedigreeNode createPedigreeFromGermplasm(Germplasm germplasm,
+									  GermplasmEntity motherGerm,
+									  GermplasmEntity fatherGerm) {
+		PedigreeNode node = new PedigreeNode();
 
 		node.setAdditionalInfo(germplasm.getAdditionalInfo());
 		node.setBreedingMethodDbId(germplasm.getBreedingMethodDbId());
@@ -568,17 +626,17 @@ public class PedigreeService {
 		node.setGermplasmPUI(germplasm.getGermplasmPUI());
 		node.setPedigreeString(germplasm.getPedigree());
 
-		if (motherOpt.isPresent()) {
+		if (motherGerm != null) {
 			PedigreeNodeParents mother = new PedigreeNodeParents();
-			mother.setGermplasmDbId(motherOpt.get().getId());
-			mother.setGermplasmName(motherOpt.get().getGermplasmName());
+			mother.setGermplasmDbId(motherGerm.getId());
+			mother.setGermplasmName(motherGerm.getGermplasmName());
 			mother.setParentType(ParentType.FEMALE);
 			node.addParentsItem(mother);
 		}
-		if (fatherOpt.isPresent()) {
+		if (fatherGerm != null) {
 			PedigreeNodeParents father = new PedigreeNodeParents();
-			father.setGermplasmDbId(fatherOpt.get().getId());
-			father.setGermplasmName(fatherOpt.get().getGermplasmName());
+			father.setGermplasmDbId(fatherGerm.getId());
+			father.setGermplasmName(fatherGerm.getGermplasmName());
 			father.setParentType(ParentType.MALE);
 			node.addParentsItem(father);
 		}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -356,33 +356,44 @@ public class PedigreeService {
 		}
 	}
 
+	// TODO: See if we can get the PUT from the GermplasmApiController to use this code as well instead of updateGermplasmPedigree()
+	public void updateGermplasmPedigreeForPost(List<Germplasm> data) throws BrAPIServerException {
+		// T = With pedigree, F = Without pedigree
+		Map<Boolean, List<Germplasm>> germsWithAndWithoutPedigree
+				= data.stream().collect(Collectors.partitioningBy(g -> g.getPedigree() != null));
+
+		if (!germsWithAndWithoutPedigree.get(true).isEmpty()) {
+			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(germsWithAndWithoutPedigree.get(true)), false);
+		}
+
+		if (!germsWithAndWithoutPedigree.get(false).isEmpty()) {
+			List<PedigreeNode> createPedigreeNodes = new ArrayList<>();
+
+			for (Germplasm germplasm : germsWithAndWithoutPedigree.get(false)) {
+				createPedigreeNodes.add(convertFromGermplasmToPedigree(germplasm));
+			}
+
+			savePedigreeNodes(createPedigreeNodes, false);
+		}
+	}
+
 	public void updateGermplasmPedigree(List<Germplasm> data) throws BrAPIServerException {
 		List<PedigreeNode> createPedigreeNodes = new ArrayList<>();
 		Map<String, PedigreeNode> updatePedigreeNodes = new HashMap<>();
 
-		// TODO: This always returns empty for the germplasm post path, since this method is always passed a newly created germplasm record.
 		Map<String, PedigreeNodeEntity> nodesByGermplasm = getExistingPedigreeNodes(
 				data.stream().map(p -> p.getGermplasmDbId()).collect(Collectors.toList()));
 
-		if (data.stream().noneMatch(g -> g.getPedigree() != null) || !nodesByGermplasm.isEmpty()) {
-			for (Germplasm germplasm : data) {
-				if (nodesByGermplasm.containsKey(germplasm.getGermplasmDbId())) {
-					updatePedigreeNodes.put(germplasm.getGermplasmDbId(), convertFromGermplasmToPedigree(germplasm));
-				} else {
-					createPedigreeNodes.add(convertFromGermplasmToPedigree(germplasm));
-				}
+		for (Germplasm germplasm : data) {
+			if (nodesByGermplasm.containsKey(germplasm.getGermplasmDbId())) {
+				updatePedigreeNodes.put(germplasm.getGermplasmDbId(), convertFromGermplasmToPedigree(germplasm));
+			} else {
+				createPedigreeNodes.add(convertFromGermplasmToPedigree(germplasm));
 			}
-
-			if (!createPedigreeNodes.isEmpty()) {
-				savePedigreeNodes(createPedigreeNodes, false);
-			}
-
-			if (!updatePedigreeNodes.isEmpty()) {
-				updatePedigreeNodes(updatePedigreeNodes, false);
-			}
-		} else {
-			savePedigreeNodes(convertFromGermplasmToPedigreeBatchUsingNames(data), false);
 		}
+
+		savePedigreeNodes(createPedigreeNodes);
+		updatePedigreeNodes(updatePedigreeNodes);
 
 	}
 
@@ -837,14 +848,12 @@ public class PedigreeService {
 
 	public PedigreeNode convertFromGermplasmToPedigree(Germplasm germplasm)
 		throws BrAPIServerException {
-		PedigreeNode node = new PedigreeNode();
 
 		List<String> pedigreeList = new ArrayList<>();
 		if (germplasm.getPedigree() != null) {
 			pedigreeList = Arrays.asList(germplasm.getPedigree().split("/"));
 		}
 
-		// TODO: Could split this up into one query in batch that returns a Map of Germplasm to its Nodes.
 		GermplasmEntity motherGerm = null;
 		GermplasmEntity fatherGerm = null;
 		if (pedigreeList.size() > 0) {

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -4,7 +4,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import io.swagger.model.IndexPagination;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
@@ -300,10 +299,8 @@ public class PedigreeService {
 			throw new BrAPIServerException(HttpStatus.BAD_REQUEST, errorMsg);
 		}
 
-		// TODO: Batch this
 		List<PedigreeNodeEntity> newEntities = createEntitiesInBatch(request);
 		// save all the new nodes without edges
-		//TODO: Fix to save nodes and edges at same time
 		pedigreeRepository.saveAll(newEntities);
 
 		Map<String, PedigreeNode> updateRequest = new HashMap<>();
@@ -341,7 +338,6 @@ public class PedigreeService {
 			}
 		}
 
-		// First, update the basic properties of the nodes in batch.
 		updateEntitiesWithEdgesInBatch(entityDtoPairsByGermplasmId);
 
 		if (returnValues) {
@@ -586,20 +582,28 @@ public class PedigreeService {
 	// This method should be used in use cases where there are no existing node entities representing the list being passed through.
 	private List<PedigreeNodeEntity> createEntitiesInBatch(List<PedigreeNode> nodes)
 		throws BrAPIServerException {
-		List<String> germIds = nodes.stream().map(PedigreeNode::getGermplasmDbId).collect(Collectors.toList());
-		List<String> crossingProjIds = nodes.stream().map(PedigreeNode::getCrossingProjectDbId).collect(Collectors.toList());
+		List<String> germIds = nodes.stream()
+				.map(PedigreeNode::getGermplasmDbId)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
+		List<String> crossingProjIds = nodes.stream()
+				.map(PedigreeNode::getCrossingProjectDbId)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
 
-		List<GermplasmEntity> germs = germplasmService.findByIds(germIds);
-		List<CrossingProjectEntity> crossingProjs = crossingProjectService.findCrossingProjectsByIds(crossingProjIds);
+		Map<String, GermplasmEntity> foundGermsById = germplasmService.findByIds(germIds)
+				.stream()
+				.collect(Collectors.toMap(BrAPIBaseEntity::getId, e -> e));
+		Map<String, CrossingProjectEntity> foundCrossingProjsById = crossingProjectService.findCrossingProjectsByIds(crossingProjIds)
+				.stream()
+				.collect(Collectors.toMap(BrAPIBaseEntity::getId, e -> e));
 
-		List<PedigreeNodeEntity> result = new ArrayList<PedigreeNodeEntity>();
+		List<PedigreeNodeEntity> result = new ArrayList<>();
 		for (PedigreeNode node : nodes) {
 			PedigreeNodeEntity entity = new PedigreeNodeEntity();
 
 			if (node.getGermplasmDbId() != null) {
-				String germId = node.getGermplasmDbId();
-				Optional<GermplasmEntity> germEntity = germs.stream().filter(ge -> ge.getId().equals(germId)).findFirst();
-				germEntity.ifPresent(entity::setGermplasm);
+				entity.setGermplasm(foundGermsById.get(node.getGermplasmDbId()));
 			}
 
 			UpdateUtility.updateEntity(node, entity);
@@ -612,9 +616,7 @@ public class PedigreeService {
 				entity.setPedigreeString(node.getPedigreeString());
 
 			if (node.getCrossingProjectDbId() != null) {
-				String cpId = node.getCrossingProjectDbId();
-				Optional<CrossingProjectEntity> crossingProjectEntity = crossingProjs.stream().filter(cp -> cp.getId().equals(cpId)).findFirst();
-                crossingProjectEntity.ifPresent(entity::setCrossingProject);
+				entity.setCrossingProject(foundCrossingProjsById.get(node.getCrossingProjectDbId()));
 			}
 
 			result.add(entity);
@@ -645,15 +647,15 @@ public class PedigreeService {
 				.map(Entry::getKey)
 				.collect(Collectors.toList());
 
-		List<GermplasmEntity> germs = new ArrayList<>();
-		List<CrossingProjectEntity> crossingProjs = new ArrayList<>();
+		new HashMap<>();
 
-		if (!germIds.isEmpty()) {
-			germs = germplasmService.findByIds(germIds);
-		}
-		if (!crossingProjIds.isEmpty()) {
-			crossingProjs = crossingProjectService.findCrossingProjectsByIds(crossingProjIds);
-		}
+		Map<String, GermplasmEntity> foundGermsById = germplasmService.findByIds(germIds)
+				.stream()
+				.collect(Collectors.toMap(BrAPIBaseEntity::getId, e -> e));
+
+		Map<String, CrossingProjectEntity> foundCrossingProjsById = crossingProjectService.findCrossingProjectsByIds(crossingProjIds)
+				.stream()
+				.collect(Collectors.toMap(BrAPIBaseEntity::getId, e -> e));
 
 		if (!germIdsWithParentNodes.isEmpty()) {
 			updateParentEdges(germIdsWithParentNodes, entityDtoPairsByGermId);
@@ -668,9 +670,7 @@ public class PedigreeService {
 			PedigreeNode node = entityDtoPairByGermId.getValue().getRight();
 
 			if (node.getGermplasmDbId() != null && entity.getGermplasm() == null) {
-				String germId = node.getGermplasmDbId();
-				Optional<GermplasmEntity> germEntity = germs.stream().filter(ge -> ge.getId().equals(germId)).findFirst();
-				germEntity.ifPresent(entity::setGermplasm);
+				entity.setGermplasm(foundGermsById.get(node.getGermplasmDbId()));
 			}
 
 			UpdateUtility.updateEntityCheckExRefs(node, entity);
@@ -683,9 +683,7 @@ public class PedigreeService {
 				entity.setPedigreeString(node.getPedigreeString());
 
 			if (node.getCrossingProjectDbId() != null) {
-				String cpId = node.getCrossingProjectDbId();
-				Optional<CrossingProjectEntity> crossingProjectEntity = crossingProjs.stream().filter(cp -> cp.getId().equals(cpId)).findFirst();
-				crossingProjectEntity.ifPresent(entity::setCrossingProject);
+				entity.setCrossingProject(foundCrossingProjsById.get(node.getCrossingProjectDbId()));
 			}
 		}
 	}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -206,7 +206,7 @@ public class PedigreeService {
 				.collect(Collectors.toSet());
 
 		List<String> germIdsWithNoPedigreeRecord = germplasmDbIds.stream()
-				.filter(gId -> !germIdsOfFoundNodes.contains(gId))
+				.filter(dbId -> !germIdsOfFoundNodes.contains(dbId))
 				.collect(Collectors.toList());
 
 		// Now see if there are germplasm records that exist from the list created above that have a pedigree associated.

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -662,7 +662,7 @@ public class PedigreeService {
 				germEntity.ifPresent(entity::setGermplasm);
 			}
 
-			UpdateUtility.updateEntity(node, entity);
+			UpdateUtility.updateEntityCheckExRefs(node, entity);
 
 			if (node.getCrossingYear() != null)
 				entity.setCrossingYear(node.getCrossingYear());

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -827,7 +827,16 @@ public class PedigreeService {
 		}
 
 		List<GermplasmEntity> motherGerms = germplasmService.findByNames(new ArrayList<>(germsByPedigreeMother.values()));
+
+		if (motherGerms.isEmpty() && !germsByPedigreeMother.isEmpty()) {
+			log.warn("Could not find any germplasms looking up with mother names {}", germsByPedigreeMother.values());
+		}
+
 		List<GermplasmEntity> fatherGerms = germplasmService.findByNames(new ArrayList<>(germsByPedigreeFather.values()));
+
+		if (fatherGerms.isEmpty() && !germsByPedigreeFather.isEmpty()) {
+			log.warn("Could not find any germplasms looking up with father names {}", germsByPedigreeFather.values());
+		}
 
 		for (Germplasm germplasm : germplasms) {
 			GermplasmEntity motherGerm = null;

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -4,6 +4,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import io.swagger.model.IndexPagination;
+import io.swagger.model.Pagination;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
@@ -406,10 +408,14 @@ public class PedigreeService {
 			searchReq.setPedigreeDepth(0);
 			searchReq.setProgenyDepth(0);
 
-			List<PedigreeNodeEntity> nodeEntities = findPedigreeEntities(searchReq, null);
+			Pagination pagination = new IndexPagination();
+			pagination.setPageSize(germplasmDbIds.size());
+			Metadata metadata = new Metadata();
+			metadata.setPagination(pagination);
+
+			List<PedigreeNodeEntity> nodeEntities = findPedigreeEntities(searchReq, metadata);
 
 			for (PedigreeNodeEntity nodeEntity : nodeEntities) {
-				// TODO: nodeEntity.getGermplasm() causes a lazy load
 				if (nodeEntity.getGermplasm() != null && nodeEntity.getGermplasm().getId() != null) {
 					nodesByGermplasm.put(nodeEntity.getGermplasm().getId(), nodeEntity);
 				}

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/PedigreeService.java
@@ -757,7 +757,7 @@ public class PedigreeService {
 
 		SearchQueryBuilder<PedigreeEdgeEntity> search = new SearchQueryBuilder<PedigreeEdgeEntity>(PedigreeEdgeEntity.class);
 
-		search.appendList(germIdsWithProgenyNodes, "connected.germplasm.id");
+		search.appendList(germIdsWithProgenyNodes, "connectedNode.germplasm.id");
 		search.appendEnum(PedigreeEdgeEntity.EdgeType.parent, "edgeType");
 		List<PedigreeEdgeEntity> existingProgenyEdges = pedigreeEdgeRepository.findAllBySearch(search);
 

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -12,11 +12,20 @@ spring.flyway.baselineOnMigrate=true
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# This property when set to true makes it so that a DB transaction is open through the body of a request, nullifying the use of @Transactional.
+# It is generally recommended that this be set to false, and methods are properly annotated and release the transactions when complete.
+# However, many of the endpoints already rely on this kind of connection infrastructure and changing is more trouble than it's worth.
+spring.jpa.open-in-view=true
+
 spring.jpa.properties.hibernate.jdbc.batch_size=50
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 spring.jpa.hibernate.ddl-auto=validate
+
+# Use these to help debug queries.
+# The stats will tell you how long hibernate transactions are taking, how many queries occur, how many entities are being flushed/accessed, etc.
 spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.generate_statistics=false
 
 spring.mvc.dispatch-options-request=true
 

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -15,7 +15,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.jdbc.batch_size=50
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
-spring.jpa.properties.hibernate.order_deletes=true
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 

--- a/src/main/resources/application.properties.template
+++ b/src/main/resources/application.properties.template
@@ -12,6 +12,10 @@ spring.flyway.baselineOnMigrate=true
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.order_deletes=true
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 


### PR DESCRIPTION
These changes should be merged on top of #49, as they are built on a branch based off those changes.

The thruput of the BrAPI Germplasm POST was very slow at the time I started working on this import.

An import of 30k germs on a clean DB or a program with no germs would take somewhere in the ballpark of 30-60 minutes.

Once the number of germs per program reached around 60-90k, the import would take hours or never finish at all.

After the host of changes made in the body of this MR, the 30k file can be imported in around 3-6 minutes on a DB with 550k germs on it with about 250k germs per program already loaded in.

It should be noted the import is much faster, but issues with the cache remain.

The associated [bi-api changes](https://github.com/Breeding-Insight/bi-api/pull/448) edited the import process so that the cache is only refreshed at the end of the import. But as the number of records grows, the cache takes longer and longer to return, and this can impact the experience of the import.

The performance is still worlds better than it was before, but sometimes the cache getting can hold things up, and because it happens at the end of the import, users may find that when they try to view the germplasm records is takes a long time to load because the cache is still fetching.

I'll try to summarize the optimizations made:

* Optimized the Germplasm save so that it creates entities in batch, and also does lookups for these entities in batch, rather than one by one.  This cut down about 2000 queries on an import size of 1000 records at a time.
* Removed `saveAndFlushAlls` everywhere.  After some research, I found that flushalls can greatly hurt performance time because if entities being saved reference entities that were flushed (as a lot of this code seems to do) hibernate has to refresh the entities, or sometimes it doesn't even know what to do and gives an error.
* Batched Pedigree creation from Germplasm records.  There were kind of a bunch of optimizations tied together in this. It's hard to estimate how many queries were killed from this batching.  anywhere between 20-30k. Without the changes from #49, performance suffered even more because the pedigree batching code kicked off full germplasm search requests, which tried paginating and fetching in memory, not only slowing the performance but bringing memory allocation to a screeching halt.
    * Batch the creation of pedigree records from germplasm when no pedigree string came in
    * Batch the creation of pedigree records from germplasm when pedigree string came in.
    * Batch the creation of pedigree edges
    * Batch the creation of pedigree edges from parents
    * Batch the creation of pedigree edges from progeny (children)
* I found that after these optimizations were made, an extraordinary amount of deletions were occurring on the `pedigree_node_external_references` table, and brought the import to a screeching halt at scale.  This ended up being due to the `UpdateUtility` unnecessarily clearing out existing external references that actual in fact already matched the ones that existed.  A check was put in place to prevent this from ever occurring, however I only applied this check to the PedigreeNode code.  Another solution to this problem could have been to just prevent setting pedigree external references entirely, as they likely do not need the same ones as germplasm.  But this issue seemed so severe and worrisome for other entities I thought it would be helpful to keep the exref checking code for reuse.
* After this discovery, I hit another sticking point: Thousands of queries being created to convert the pedigree database data to DTOs which was being completely dropped on the floor in the case of the Germplasm POST.  I created some new method signatures to prevent the dto conversion from ever happening for this use case.  NOTE: This does not affect the data returned, as the data returned only returns germplasm data, and I kept those conversions untouched.
* Added batching spring.data properties to the `application.properties.template`.  These must be replicated to the `application.properties` of the relevant application/deployment, as they are imperative for speedups relating to batch inserts